### PR TITLE
Set up CLI framework

### DIFF
--- a/app/ethermint.go
+++ b/app/ethermint.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"os"
+
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -29,6 +31,9 @@ const appName = "Ethermint"
 
 // application multi-store keys
 var (
+	// default home directories for the application CLI
+	DefaultCLIHome = os.ExpandEnv("$HOME/.emintcli")
+
 	storeKeyAccount     = sdk.NewKVStoreKey("acc")
 	storeKeyStorage     = sdk.NewKVStoreKey("contract_storage")
 	storeKeyMain        = sdk.NewKVStoreKey("main")

--- a/cmd/emintcli/main.go
+++ b/cmd/emintcli/main.go
@@ -1,7 +1,82 @@
 package main
 
+import (
+	"os"
+	"path"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/keys"
+	"github.com/cosmos/cosmos-sdk/client/rpc"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	emintapp "github.com/cosmos/ethermint/app"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/tendermint/tendermint/libs/cli"
+)
+
 func main() {
-	// TODO: Implement CLI commands and logic
-	//
-	// Ref: https://github.com/cosmos/ethermint/issues/432
+	cobra.EnableCommandSorting = false
+
+	// TODO: Set up codec
+
+	// Read in the configuration file for the sdk
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(sdk.Bech32PrefixAccAddr, sdk.Bech32PrefixAccPub)
+	config.SetBech32PrefixForValidator(sdk.Bech32PrefixValAddr, sdk.Bech32PrefixValPub)
+	config.SetBech32PrefixForConsensusNode(sdk.Bech32PrefixConsAddr, sdk.Bech32PrefixConsPub)
+	config.Seal()
+
+	rootCmd := &cobra.Command{
+		Use:   "emintcli",
+		Short: "Ethermint Client",
+	}
+
+	// Add --chain-id to persistent flags and mark it required
+	rootCmd.PersistentFlags().String(client.FlagChainID, "", "Chain ID of tendermint node")
+	rootCmd.PersistentPreRunE = func(_ *cobra.Command, _ []string) error {
+		return initConfig(rootCmd)
+	}
+
+	// Construct Root Command
+	rootCmd.AddCommand(
+		rpc.StatusCommand(),
+		client.ConfigCmd(emintapp.DefaultCLIHome),
+		// TODO: Set up query command
+		// TODO: Set up tx command
+		// TODO: Set up rest routes (if included, different from web3 api)
+		// TODO: Set up web3 API setup command?
+		client.LineBreak,
+		keys.Commands(),
+		client.LineBreak,
+	)
+
+	executor := cli.PrepareMainCmd(rootCmd, "EM", emintapp.DefaultCLIHome)
+	err := executor.Execute()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func initConfig(cmd *cobra.Command) error {
+	home, err := cmd.PersistentFlags().GetString(cli.HomeFlag)
+	if err != nil {
+		return err
+	}
+
+	cfgFile := path.Join(home, "config", "config.toml")
+	if _, err := os.Stat(cfgFile); err == nil {
+		viper.SetConfigFile(cfgFile)
+
+		if err := viper.ReadInConfig(); err != nil {
+			return err
+		}
+	}
+	if err := viper.BindPFlag(client.FlagChainID, cmd.PersistentFlags().Lookup(client.FlagChainID)); err != nil {
+		return err
+	}
+	if err := viper.BindPFlag(cli.EncodingFlag, cmd.PersistentFlags().Lookup(cli.EncodingFlag)); err != nil {
+		return err
+	}
+	return viper.BindPFlag(cli.OutputFlag, cmd.PersistentFlags().Lookup(cli.OutputFlag))
 }

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,8 @@ require (
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/rjeczalik/notify v0.9.2 // indirect
+	github.com/spf13/cobra v0.0.5
+	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.3.0
 	github.com/syndtr/goleveldb v0.0.0-20181105012736-f9080354173f // indirect
 	github.com/tendermint/lint v0.0.1 // indirect


### PR DESCRIPTION
Sets up ethermint CLI framework to be connected to logic implemented in future PRs. Defaults include commands for checking status of daemon rpc, setting up keys, and setting up config for the daemon. Here is the output for the base command:

```
Ethermint Client

Usage:
  emintcli [command]

Available Commands:
  status      Query remote node for status
  config      Create or query an application CLI configuration file

  keys        Add or view local private keys

  help        Help about any command

Flags:
      --chain-id string   Chain ID of tendermint node
  -e, --encoding string   Binary encoding (hex|b64|btc) (default "hex")
  -h, --help              help for emintcli
      --home string       directory for config and data (default "/Users/austinabell/.emintcli")
  -o, --output string     Output format (text|json) (default "text")
      --trace             print out full stack trace on errors

Use "emintcli [command] --help" for more information about a command.
```

Doesn't include setting up query, tx, rest api routes (Cosmos SDK server for cli alternative), and web3 API commands. As we discussed, starting the web3 rpc server should go through the CLI so I added the todo there.

Implements #5 