### PR TITLE
Daemon framework

### DIFF
--- a/cmd/emintd/main.go
+++ b/cmd/emintd/main.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"encoding/json"
-	"io"
-
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/x/genaccounts"
 	genaccscli "github.com/cosmos/cosmos-sdk/x/genaccounts/client/cli"
@@ -11,14 +8,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tendermint/tendermint/libs/cli"
-	"github.com/tendermint/tendermint/libs/log"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	emintapp "github.com/cosmos/ethermint/app"
-	abci "github.com/tendermint/tendermint/abci/types"
-	dbm "github.com/tendermint/tendermint/libs/db"
-	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 func main() {
@@ -61,26 +54,26 @@ func main() {
 	}
 }
 
-func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) abci.Application {
-	return emintapp.NewEthermintApp(logger, db)
-}
+// func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) abci.Application {
+// 	return emintapp.NewEthermintApp(logger, db)
+// }
 
-func exportAppStateAndTMValidators(
-	logger log.Logger, db dbm.DB, traceStore io.Writer, height int64, forZeroHeight bool, jailWhiteList []string,
-) (json.RawMessage, []tmtypes.GenesisValidator, error) {
+// func exportAppStateAndTMValidators(
+// 	logger log.Logger, db dbm.DB, traceStore io.Writer, height int64, forZeroHeight bool, jailWhiteList []string,
+// ) (json.RawMessage, []tmtypes.GenesisValidator, error) {
 
-	// if height != -1 {
-	// 	emintApp := emintapp.NewEthermintApp(logger, db)
-	// 	err := emintApp.LoadHeight(height)
-	// 	if err != nil {
-	// 		return nil, nil, err
-	// 	}
-	// 	return emintApp.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
-	// }
+// 	// if height != -1 {
+// 	// 	emintApp := emintapp.NewEthermintApp(logger, db)
+// 	// 	err := emintApp.LoadHeight(height)
+// 	// 	if err != nil {
+// 	// 		return nil, nil, err
+// 	// 	}
+// 	// 	return emintApp.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
+// 	// }
 
-	// emintApp := emintapp.NewEthermintApp(logger, db)
+// 	// emintApp := emintapp.NewEthermintApp(logger, db)
 
-	// return emintApp.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
-	// TODO: Unstub method
-	return json.RawMessage{}, []tmtypes.GenesisValidator{}, nil
-}
+// 	// return emintApp.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
+// 	// TODO: Unstub method
+// 	return json.RawMessage{}, []tmtypes.GenesisValidator{}, nil
+// }

--- a/cmd/emintd/main.go
+++ b/cmd/emintd/main.go
@@ -1,7 +1,86 @@
 package main
 
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/x/genaccounts"
+	genaccscli "github.com/cosmos/cosmos-sdk/x/genaccounts/client/cli"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+
+	"github.com/spf13/cobra"
+	"github.com/tendermint/tendermint/libs/cli"
+	"github.com/tendermint/tendermint/libs/log"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
+	emintapp "github.com/cosmos/ethermint/app"
+	abci "github.com/tendermint/tendermint/abci/types"
+	dbm "github.com/tendermint/tendermint/libs/db"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
 func main() {
-	// TODO: Implement daemon command and logic
-	//
-	// Ref: https://github.com/cosmos/ethermint/issues/433
+	cobra.EnableCommandSorting = false
+
+	cdc := emintapp.MakeCodec()
+
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(sdk.Bech32PrefixAccAddr, sdk.Bech32PrefixAccPub)
+	config.SetBech32PrefixForValidator(sdk.Bech32PrefixValAddr, sdk.Bech32PrefixValPub)
+	config.SetBech32PrefixForConsensusNode(sdk.Bech32PrefixConsAddr, sdk.Bech32PrefixConsPub)
+	config.Seal()
+
+	ctx := server.NewDefaultContext()
+
+	rootCmd := &cobra.Command{
+		Use:               "emintd",
+		Short:             "Ethermint App Daemon (server)",
+		PersistentPreRunE: server.PersistentPreRunEFn(ctx),
+	}
+	// CLI commands to initialize the chain
+	rootCmd.AddCommand(
+		genutilcli.InitCmd(ctx, cdc, emintapp.ModuleBasics, emintapp.DefaultNodeHome),
+		genutilcli.CollectGenTxsCmd(ctx, cdc, genaccounts.AppModuleBasic{}, emintapp.DefaultNodeHome),
+		genutilcli.GenTxCmd(ctx, cdc, emintapp.ModuleBasics, staking.AppModuleBasic{}, genaccounts.AppModuleBasic{}, emintapp.DefaultNodeHome, emintapp.DefaultCLIHome),
+		genutilcli.ValidateGenesisCmd(ctx, cdc, emintapp.ModuleBasics),
+
+		// AddGenesisAccountCmd allows users to add accounts to the genesis file
+		genaccscli.AddGenesisAccountCmd(ctx, cdc, emintapp.DefaultNodeHome, emintapp.DefaultCLIHome),
+	)
+
+	// TODO: Add export app state and TM validators commands
+	// server.AddCommands(ctx, cdc, rootCmd, newApp, exportAppStateAndTMValidators)
+
+	// prepare and add flags
+	executor := cli.PrepareBaseCmd(rootCmd, "EM", emintapp.DefaultNodeHome)
+	err := executor.Execute()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) abci.Application {
+	return emintapp.NewEthermintApp(logger, db)
+}
+
+func exportAppStateAndTMValidators(
+	logger log.Logger, db dbm.DB, traceStore io.Writer, height int64, forZeroHeight bool, jailWhiteList []string,
+) (json.RawMessage, []tmtypes.GenesisValidator, error) {
+
+	// if height != -1 {
+	// 	emintApp := emintapp.NewEthermintApp(logger, db)
+	// 	err := emintApp.LoadHeight(height)
+	// 	if err != nil {
+	// 		return nil, nil, err
+	// 	}
+	// 	return emintApp.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
+	// }
+
+	// emintApp := emintapp.NewEthermintApp(logger, db)
+
+	// return emintApp.ExportAppStateAndValidators(forZeroHeight, jailWhiteList)
+	// TODO: Unstub method
+	return json.RawMessage{}, []tmtypes.GenesisValidator{}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/golangci/golangci-lint v1.17.1 // indirect
 	github.com/google/uuid v1.0.0 // indirect
 	github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8 // indirect
+	github.com/gorilla/mux v1.7.0
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/huin/goupnp v1.0.0 // indirect
 	github.com/influxdata/influxdb v1.7.7 // indirect


### PR DESCRIPTION
- Implements basic daemon framework, to be connected to start the tendermint node when #64 is implemented

Current workflow to set up the chain using the daemon (and cli):

```bash
$  emintd init test --chain-id ethermint
{
  "moniker": "test",
  "chain_id": "ethermint",
  "node_id": "7df2f2687ad8690792076f366828d0bc8833b98e",
  "gentxs_dir": "",
  "app_message": {
    "ethermint": {
      "accounts": []
    },
    "staking": {
      "params": {
        "unbonding_time": "259200000000000",
        "max_validators": 100,
        "max_entries": 7,
        "bond_denom": "stake"
      },
      "last_total_power": "0",
      "last_validator_powers": null,
      "validators": null,
      "delegations": null,
      "unbonding_delegations": null,
      "redelegations": null,
      "exported": false
    },
    "slashing": {
      "params": {
        "max_evidence_age": "120000000000",
        "signed_blocks_window": "100",
        "min_signed_per_window": "0.500000000000000000",
        "downtime_jail_duration": "600000000000",
        "slash_fraction_double_sign": "0.050000000000000000",
        "slash_fraction_downtime": "0.010000000000000000"
      },
      "signing_infos": {},
      "missed_blocks": {}
    },
    "distribution": {
      "fee_pool": {
        "community_pool": []
      },
      "community_tax": "0.020000000000000000",
      "base_proposer_reward": "0.010000000000000000",
      "bonus_proposer_reward": "0.040000000000000000",
      "withdraw_addr_enabled": true,
      "delegator_withdraw_infos": [],
      "previous_proposer": "",
      "outstanding_rewards": [],
      "validator_accumulated_commissions": [],
      "validator_historical_rewards": [],
      "validator_current_rewards": [],
      "delegator_starting_infos": [],
      "validator_slash_events": []
    },
    "accounts": [],
    "genutil": {
      "gentxs": null
    },
    "bank": {
      "send_enabled": true
    },
    "params": null,
    "auth": {
      "params": {
        "max_memo_characters": "256",
        "tx_sig_limit": "7",
        "tx_size_cost_per_byte": "10",
        "sig_verify_cost_ed25519": "590",
        "sig_verify_cost_secp256k1": "1000"
      }
    }
  }
}
$  emintcli keys add austin
override the existing name austin [y/N]: y
Enter a passphrase to encrypt your key to disk:
Repeat the passphrase:

- name: austin
  type: local
  address: cosmos1w94eq0mmdxnc820ucapesyxm3upzgdd3f46qxm
  pubkey: cosmospub1addwnpepq22djc2ujh7yj40t0e36vufp89w5a7yfq9cd99sy3y2c0ed4xsht22ut52k
  mnemonic: ""
  threshold: 0
  pubkeys: []

$  emintd add-genesis-account $(emintcli keys show austin -a) 1000photon,100000000stake
$  emintd gentx --name austin
Password to sign with 'austin':
Genesis transaction written to "/Users/austinabell/.emintd/config/gentx/gentx-7df2f2687ad8690792076f366828d0bc8833b98e.json"
$  emintd validate-genesis
validating genesis file at /Users/austinabell/.emintd/config/genesis.json
File at /Users/austinabell/.emintd/config/genesis.json is a valid genesis file
```

Commands include:
```
Ethermint App Daemon (server)

Usage:
  emintd [command]

Available Commands:
  init                Initialize private validator, p2p, genesis, and application configuration files
  collect-gentxs      Collect genesis txs and output a genesis.json file
  gentx               Generate a genesis tx carrying a self delegation
  validate-genesis    validates the genesis file at the default location or at the location passed as an arg
  add-genesis-account Add genesis account to genesis.json
  help                Help about any command

Flags:
  -h, --help          help for emintd
      --home string   directory for config and data (default "/Users/austinabell/.emintd")
      --trace         print out full stack trace on errors
```

Which the final daemon cobra commands for:

```
  start               Run the full node
  unsafe-reset-all    Resets the blockchain database, removes address book files, and resets priv_validator.json to the genesis state

  tendermint          Tendermint subcommands
  export              Export state to JSON

  version             Print the app version
```

will come from:
```
	// TODO: Add export app state and TM validators commands
	// server.AddCommands(ctx, cdc, rootCmd, newApp, exportAppStateAndTMValidators)
```

When #64 is completed and the ethermint app framework is finished to make the `exportAppStateAndTMValidators` function that is commented out implementable