### PR TITLE
CSDB Keeper

### DIFF
--- a/app/ethermint.go
+++ b/app/ethermint.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"github.com/cosmos/ethermint/x/evm"
 	"os"
 
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
@@ -58,6 +59,7 @@ var (
 		crisis.AppModuleBasic{},
 		slashing.AppModuleBasic{},
 		supply.AppModuleBasic{},
+		evm.AppModuleBasic{},
 	)
 )
 
@@ -96,7 +98,8 @@ type EthermintApp struct {
 	keyGov      *sdk.KVStoreKey
 	keyParams   *sdk.KVStoreKey
 	tkeyParams  *sdk.TransientStoreKey
-	// TODO: Add evm module key
+	evmStoreKey *sdk.KVStoreKey
+	evmCodeKey *sdk.KVStoreKey
 
 	// keepers
 	accountKeeper  auth.AccountKeeper
@@ -109,7 +112,7 @@ type EthermintApp struct {
 	govKeeper      gov.Keeper
 	crisisKeeper   crisis.Keeper
 	paramsKeeper   params.Keeper
-	// TODO: Include evm Keeper
+	evmKeeper		evm.Keeper
 
 	// the module manager
 	mm *module.Manager
@@ -144,7 +147,8 @@ func NewEthermintApp(logger tmlog.Logger, db dbm.DB, loadLatest bool,
 		keyGov:         sdk.NewKVStoreKey(gov.StoreKey),
 		keyParams:      sdk.NewKVStoreKey(params.StoreKey),
 		tkeyParams:     sdk.NewTransientStoreKey(params.TStoreKey),
-		// TODO: Initialize evm module key
+		evmStoreKey: sdk.NewKVStoreKey(params.StoreKey),
+		evmCodeKey: sdk.NewKVStoreKey(params.StoreKey),
 	}
 
 	// init params keeper and subspaces
@@ -180,7 +184,7 @@ func NewEthermintApp(logger tmlog.Logger, db dbm.DB, loadLatest bool,
 	app.slashingKeeper = slashing.NewKeeper(app.cdc, app.keySlashing, &stakingKeeper,
 		slashingSubspace, slashing.DefaultCodespace)
 	app.crisisKeeper = crisis.NewKeeper(crisisSubspace, invCheckPeriod, app.supplyKeeper, auth.FeeCollectorName)
-	// TODO: Instantiate evm Keeper
+	app.evmKeeper = evm.NewKeeper(app.accountKeeper, app.evmStoreKey, app.evmCodeKey)
 
 	// register the proposal types
 	govRouter := gov.NewRouter()
@@ -220,7 +224,7 @@ func NewEthermintApp(logger tmlog.Logger, db dbm.DB, loadLatest bool,
 	// initialized with tokens from genesis accounts.
 	app.mm.SetOrderInitGenesis(genaccounts.ModuleName, supply.ModuleName, distr.ModuleName,
 		staking.ModuleName, auth.ModuleName, bank.ModuleName, slashing.ModuleName,
-		gov.ModuleName, mint.ModuleName, crisis.ModuleName, genutil.ModuleName)
+		gov.ModuleName, mint.ModuleName, crisis.ModuleName, genutil.ModuleName, evmtypes.ModuleName)
 
 	app.mm.RegisterInvariants(&app.crisisKeeper)
 	app.mm.RegisterRoutes(app.Router(), app.QueryRouter())
@@ -228,7 +232,7 @@ func NewEthermintApp(logger tmlog.Logger, db dbm.DB, loadLatest bool,
 	// initialize stores
 	app.MountStores(app.keyMain, app.keyAccount, app.keySupply, app.keyStaking,
 		app.keyMint, app.keyDistr, app.keySlashing, app.keyGov, app.keyParams,
-		app.tkeyParams, app.tkeyStaking, app.tkeyDistr)
+		app.tkeyParams, app.tkeyStaking, app.tkeyDistr, app.evmStoreKey, app.evmCodeKey)
 
 	// initialize BaseApp
 	app.SetInitChainer(app.InitChainer)

--- a/app/ethermint.go
+++ b/app/ethermint.go
@@ -100,7 +100,7 @@ type EthermintApp struct {
 	keyParams   *sdk.KVStoreKey
 	tkeyParams  *sdk.TransientStoreKey
 	evmStoreKey *sdk.KVStoreKey
-	evmCodeKey *sdk.KVStoreKey
+	evmCodeKey  *sdk.KVStoreKey
 
 	// keepers
 	accountKeeper  auth.AccountKeeper
@@ -113,7 +113,7 @@ type EthermintApp struct {
 	govKeeper      gov.Keeper
 	crisisKeeper   crisis.Keeper
 	paramsKeeper   params.Keeper
-	evmKeeper		evm.Keeper
+	evmKeeper      evm.Keeper
 
 	// the module manager
 	mm *module.Manager
@@ -148,8 +148,8 @@ func NewEthermintApp(logger tmlog.Logger, db dbm.DB, loadLatest bool,
 		keyGov:         sdk.NewKVStoreKey(gov.StoreKey),
 		keyParams:      sdk.NewKVStoreKey(params.StoreKey),
 		tkeyParams:     sdk.NewTransientStoreKey(params.TStoreKey),
-		evmStoreKey: sdk.NewKVStoreKey(evmtypes.EvmStoreKey),
-		evmCodeKey: sdk.NewKVStoreKey(evmtypes.EvmCodeKey),
+		evmStoreKey:    sdk.NewKVStoreKey(evmtypes.EvmStoreKey),
+		evmCodeKey:     sdk.NewKVStoreKey(evmtypes.EvmCodeKey),
 	}
 
 	// init params keeper and subspaces

--- a/app/ethermint.go
+++ b/app/ethermint.go
@@ -59,7 +59,8 @@ var (
 		crisis.AppModuleBasic{},
 		slashing.AppModuleBasic{},
 		supply.AppModuleBasic{},
-		evm.AppModuleBasic{},
+		// TODO: Enable EVM AppModuleBasic
+		//evm.AppModuleBasic{},
 	)
 )
 
@@ -147,8 +148,8 @@ func NewEthermintApp(logger tmlog.Logger, db dbm.DB, loadLatest bool,
 		keyGov:         sdk.NewKVStoreKey(gov.StoreKey),
 		keyParams:      sdk.NewKVStoreKey(params.StoreKey),
 		tkeyParams:     sdk.NewTransientStoreKey(params.TStoreKey),
-		evmStoreKey: sdk.NewKVStoreKey(params.StoreKey),
-		evmCodeKey: sdk.NewKVStoreKey(params.StoreKey),
+		evmStoreKey: sdk.NewKVStoreKey(evmtypes.EvmStoreKey),
+		evmCodeKey: sdk.NewKVStoreKey(evmtypes.EvmCodeKey),
 	}
 
 	// init params keeper and subspaces

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -50,8 +50,8 @@ var (
 	// paramsKey  = sdk.NewKVStoreKey("params")
 	// tParamsKey = sdk.NewTransientStoreKey("transient_params")
 	accKey     = sdk.NewKVStoreKey("acc")
-	storageKey = sdk.NewKVStoreKey("storage")
-	codeKey    = sdk.NewKVStoreKey("code")
+	storageKey = sdk.NewKVStoreKey(evmtypes.EvmStoreKey)
+	codeKey    = sdk.NewKVStoreKey(evmtypes.EvmCodeKey)
 
 	logger = tmlog.NewNopLogger()
 
@@ -306,7 +306,7 @@ func accumulateRewards(
 // ApplyDAOHardFork modifies the state database according to the DAO hard-fork
 // rules, transferring all balances of a set of DAO accounts to a single refund
 // contract.
-// Code is pulled from go-ethereum 1.9 because the StateDB interface does not include the 
+// Code is pulled from go-ethereum 1.9 because the StateDB interface does not include the
 // SetBalance function implementation
 // Ref: https://github.com/ethereum/go-ethereum/blob/52f2461774bcb8cdd310f86b4bc501df5b783852/consensus/misc/dao.go#L74
 func applyDAOHardFork(statedb *evmtypes.CommitStateDB) {

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -103,8 +103,7 @@ func createAndTestGenesis(t *testing.T, cms sdk.CommitMultiStore, ak auth.Accoun
 	ms := cms.CacheMultiStore()
 	ctx := sdk.NewContext(ms, abci.Header{}, false, logger)
 
-	stateDB, err := evmtypes.NewCommitStateDB(ctx, ak, storageKey, codeKey)
-	require.NoError(t, err, "failed to create a StateDB instance")
+	stateDB := evmtypes.NewCommitStateDB(ctx, ak, storageKey, codeKey)
 
 	// sort the addresses and insertion of key/value pairs matters
 	genAddrs := make([]string, len(genBlock.Alloc))
@@ -136,7 +135,7 @@ func createAndTestGenesis(t *testing.T, cms sdk.CommitMultiStore, ak auth.Accoun
 	// commit the stateDB with 'false' to delete empty objects
 	//
 	// NOTE: Commit does not yet return the intra merkle root (version)
-	_, err = stateDB.Commit(false)
+	_, err := stateDB.Commit(false)
 	require.NoError(t, err)
 
 	// persist multi-store cache state
@@ -269,9 +268,7 @@ func TestImportBlocks(t *testing.T) {
 }
 
 func createStateDB(t *testing.T, ctx sdk.Context, ak auth.AccountKeeper) *evmtypes.CommitStateDB {
-	stateDB, err := evmtypes.NewCommitStateDB(ctx, ak, storageKey, codeKey)
-	require.NoError(t, err, "failed to create a StateDB instance")
-
+	stateDB := evmtypes.NewCommitStateDB(ctx, ak, storageKey, codeKey)
 	return stateDB
 }
 

--- a/x/evm/keeper.go
+++ b/x/evm/keeper.go
@@ -1,0 +1,251 @@
+package evm
+
+import (
+	ethcmn "github.com/ethereum/go-ethereum/common"
+	ethvm "github.com/ethereum/go-ethereum/core/vm"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	types "github.com/cosmos/ethermint/x/evm/types"
+	ethstate "github.com/ethereum/go-ethereum/core/state"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	"math/big"
+)
+
+// Keeper wraps the CommitStateDB, allowing us to pass in SDK context while adehreing
+// to the StateDB interface
+type Keeper struct {
+	csdb *types.CommitStateDB
+}
+
+func NewKeeper(ak auth.AccountKeeper, storageKey, codeKey sdk.StoreKey) Keeper {
+	return Keeper{
+		csdb: types.NewCommitStateDB(sdk.Context{}, ak, storageKey, codeKey),
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Setters
+// ----------------------------------------------------------------------------
+
+// Calls CommitStateDB.SetBalance using the passed in context
+func (k *Keeper) SetBalance(ctx sdk.Context, addr ethcmn.Address, amount *big.Int) {
+	k.csdb.WithContext(ctx).SetBalance(addr, amount)
+}
+
+// Calls CommitStateDB.AddBalance using the passed in context
+func (k *Keeper) AddBalance(ctx sdk.Context, addr ethcmn.Address, amount *big.Int) {
+	k.csdb.WithContext(ctx).AddBalance(addr, amount)
+}
+
+// Calls CommitStateDB.SubBalance using the passed in context
+func (k *Keeper) SubBalance(ctx sdk.Context, addr ethcmn.Address, amount *big.Int) {
+	k.csdb.WithContext(ctx).SubBalance(addr, amount)
+}
+
+// Calls CommitStateDB.SetNonce using the passed in context
+func (k *Keeper) SetNonce(ctx sdk.Context, addr ethcmn.Address, nonce uint64) {
+	k.csdb.WithContext(ctx).SetNonce(addr, nonce)
+}
+
+// Calls CommitStateDB.SetState using the passed in context
+func (k *Keeper) SetState(ctx sdk.Context, addr ethcmn.Address, key, value ethcmn.Hash) {
+	k.csdb.WithContext(ctx).SetState(addr, key, value)
+}
+
+// Calls CommitStateDB.SetCode using the passed in context
+func (k *Keeper) SetCode(ctx sdk.Context, addr ethcmn.Address, code []byte) {
+	k.csdb.WithContext(ctx).SetCode(addr, code)
+}
+
+// Calls CommitStateDB.AddLog using the passed in context
+func (k *Keeper) AddLog(ctx sdk.Context, log *ethtypes.Log) {
+	k.csdb.WithContext(ctx).AddLog(log)
+}
+
+// Calls CommitStateDB.AddPreimage using the passed in context
+func (k *Keeper) AddPreimage(ctx sdk.Context, hash ethcmn.Hash, preimage []byte) {
+	k.csdb.WithContext(ctx).AddPreimage(hash, preimage)
+}
+
+// Calls CommitStateDB.AddRefund using the passed in context
+func (k *Keeper) AddRefund(ctx sdk.Context, gas uint64) {
+	k.csdb.WithContext(ctx).AddRefund(gas)
+}
+
+// Calls CommitStateDB.SubRefund using the passed in context
+func (k *Keeper) SubRefund(ctx sdk.Context, gas uint64) {
+	k.csdb.WithContext(ctx).SubRefund(gas)
+}
+
+// ----------------------------------------------------------------------------
+// Getters
+// ----------------------------------------------------------------------------
+
+// Calls CommitStateDB.GetBalance using the passed in context
+func (k *Keeper) GetBalance(ctx sdk.Context, addr ethcmn.Address) *big.Int {
+	return k.csdb.WithContext(ctx).GetBalance(addr)
+}
+
+// Calls CommitStateDB.GetNonce using the passed in context
+func (k *Keeper) GetNonce(ctx sdk.Context, addr ethcmn.Address) uint64 {
+	return k.csdb.WithContext(ctx).GetNonce(addr)
+}
+
+// Calls CommitStateDB.TxIndex using the passed in context
+func (k *Keeper) TxIndex(ctx sdk.Context) int {
+	return k.csdb.WithContext(ctx).TxIndex()
+}
+
+// Calls CommitStateDB.BlockHash using the passed in context
+func (k *Keeper) BlockHash(ctx sdk.Context) ethcmn.Hash {
+	return k.csdb.WithContext(ctx).BlockHash()
+}
+
+// Calls CommitStateDB.GetCode using the passed in context
+func (k *Keeper) GetCode(ctx sdk.Context, addr ethcmn.Address) []byte {
+	return k.csdb.WithContext(ctx).GetCode(addr)
+}
+
+// Calls CommitStateDB.GetCodeSize using the passed in context
+func (k *Keeper) GetCodeSize(ctx sdk.Context, addr ethcmn.Address) int {
+	return k.csdb.WithContext(ctx).GetCodeSize(addr)
+}
+
+// Calls CommitStateDB.GetCodeHash using the passed in context
+func (k *Keeper) GetCodeHash(ctx sdk.Context, addr ethcmn.Address) ethcmn.Hash {
+	return k.csdb.WithContext(ctx).GetCodeHash(addr)
+}
+
+// Calls CommitStateDB.GetState using the passed in context
+func (k *Keeper) GetState(ctx sdk.Context, addr ethcmn.Address, hash ethcmn.Hash) ethcmn.Hash {
+	return k.csdb.WithContext(ctx).GetState(addr, hash)
+}
+
+// Calls CommitStateDB.GetCommittedState using the passed in context
+func (k *Keeper) GetCommittedState(ctx sdk.Context, addr ethcmn.Address, hash ethcmn.Hash) ethcmn.Hash {
+	return k.csdb.WithContext(ctx).GetCommittedState(addr, hash)
+}
+
+// Calls CommitStateDB.GetLogs using the passed in context
+func (k *Keeper) GetLogs(ctx sdk.Context, hash ethcmn.Hash) []*ethtypes.Log {
+	return k.csdb.WithContext(ctx).GetLogs(hash)
+}
+
+// Calls CommitStateDB.Logs using the passed in context
+func (k *Keeper) Logs(ctx sdk.Context) []*ethtypes.Log {
+	return k.csdb.WithContext(ctx).Logs()
+}
+
+// Calls CommitStateDB.GetRefund using the passed in context
+func (k *Keeper) GetRefund(ctx sdk.Context) uint64 {
+	return k.csdb.WithContext(ctx).GetRefund()
+}
+
+// Calls CommitStateDB.Preimages using the passed in context
+func (k *Keeper) Preimages(ctx sdk.Context) map[ethcmn.Hash][]byte {
+	return k.csdb.WithContext(ctx).Preimages()
+}
+
+// Calls CommitStateDB.HasSuicided using the passed in context
+func (k *Keeper) HasSuicided(ctx sdk.Context, addr ethcmn.Address) bool {
+	return k.csdb.WithContext(ctx).HasSuicided(addr)
+}
+
+// Calls CommitStateDB.StorageTrie using the passed in context
+func (k *Keeper) StorageTrie(ctx sdk.Context, addr ethcmn.Address) ethstate.Trie {
+	return k.csdb.WithContext(ctx).StorageTrie(addr)
+}
+
+// ----------------------------------------------------------------------------
+// Persistence
+// ----------------------------------------------------------------------------
+
+// Calls CommitStateDB.Commit using the passed in context
+func (k *Keeper) Commit(ctx sdk.Context, deleteEmptyObjects bool) (root ethcmn.Hash, err error) {
+	return k.csdb.WithContext(ctx).Commit(deleteEmptyObjects)
+}
+
+// Calls CommitStateDB.Finalise using the passed in context
+func (k *Keeper) Finalise(ctx sdk.Context, deleteEmptyObjects bool) {
+	k.csdb.WithContext(ctx).Finalise(deleteEmptyObjects)
+}
+
+// Calls CommitStateDB.IntermediateRoot using the passed in context
+func (k *Keeper) IntermediateRoot(ctx sdk.Context, deleteEmptyObjects bool) {
+	k.csdb.WithContext(ctx).IntermediateRoot(deleteEmptyObjects)
+}
+
+// ----------------------------------------------------------------------------
+// Snapshotting
+// ----------------------------------------------------------------------------
+
+// Calls CommitStateDB.Snapshot using the passed in context
+func (k *Keeper) Snapshot(ctx sdk.Context) int {
+	return k.csdb.WithContext(ctx).Snapshot()
+}
+
+// Calls CommitStateDB.RevertToSnapshot using the passed in context
+func (k *Keeper) RevertToSnapshot(ctx sdk.Context, revID int) {
+	k.csdb.WithContext(ctx).RevertToSnapshot(revID)
+}
+
+// ----------------------------------------------------------------------------
+// Auxiliary
+// ----------------------------------------------------------------------------
+
+// Calls CommitStateDB.Database using the passed in context
+func (k *Keeper) Database(ctx sdk.Context) ethstate.Database {
+	return k.csdb.WithContext(ctx).Database()
+}
+
+// Calls CommitStateDB.Empty using the passed in context
+func (k *Keeper) Empty(ctx sdk.Context, addr ethcmn.Address) bool {
+	return k.csdb.WithContext(ctx).Empty(addr)
+}
+
+// Calls CommitStateDB.Exist using the passed in context
+func (k *Keeper) Exist(ctx sdk.Context, addr ethcmn.Address) bool {
+	return k.csdb.WithContext(ctx).Exist(addr)
+}
+
+// Calls CommitStateDB.Error using the passed in context
+func (k *Keeper) Error(ctx sdk.Context) error {
+	return k.csdb.WithContext(ctx).Error()
+}
+
+// Calls CommitStateDB.Suicide using the passed in context
+func (k *Keeper) Suicide(ctx sdk.Context, addr ethcmn.Address) bool {
+	return k.csdb.WithContext(ctx).Suicide(addr)
+}
+
+// Calls CommitStateDB.Reset using the passed in context
+func (k *Keeper) Reset(ctx sdk.Context, root ethcmn.Hash) error {
+	return k.csdb.WithContext(ctx).Reset(root)
+}
+
+// Calls CommitStateDB.Prepare using the passed in context
+func (k *Keeper) Prepare(ctx sdk.Context, thash, bhash ethcmn.Hash, txi int) {
+	k.csdb.WithContext(ctx).Prepare(thash, bhash, txi)
+}
+
+// Calls CommitStateDB.CreateAccount using the passed in context
+func (k *Keeper) CreateAccount(ctx sdk.Context, addr ethcmn.Address) {
+	k.csdb.WithContext(ctx).CreateAccount(addr)
+}
+
+// Calls CommitStateDB.Copy using the passed in context
+func (k *Keeper) Copy(ctx sdk.Context) ethvm.StateDB {
+	return k.csdb.WithContext(ctx).Copy()
+}
+
+// Calls CommitStateDB.ForEachStorage using passed in context
+func (k *Keeper) ForEachStorage(ctx sdk.Context, addr ethcmn.Address, cb func(key, value ethcmn.Hash) bool) error {
+	return k.csdb.WithContext(ctx).ForEachStorage(addr, cb)
+}
+
+// Calls CommitStateDB.GetOrNetStateObject using the passed in context
+func (k *Keeper) GetOrNewStateObject(ctx sdk.Context, addr ethcmn.Address) types.StateObject {
+	return k.csdb.WithContext(ctx).GetOrNewStateObject(addr)
+}

--- a/x/evm/keeper.go
+++ b/x/evm/keeper.go
@@ -13,7 +13,7 @@ import (
 	"math/big"
 )
 
-// Keeper wraps the CommitStateDB, allowing us to pass in SDK context while adehreing
+// Keeper wraps the CommitStateDB, allowing us to pass in SDK context while adhering
 // to the StateDB interface
 type Keeper struct {
 	csdb *types.CommitStateDB

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -4,7 +4,6 @@ const (
 	// module name
 	ModuleName = "ethermint"
 
-	// TODO: Use this
-	// StoreKey to be used when creating the KVStore
-	StoreKey = ModuleName
+	EvmStoreKey = "evmstore"
+	EvmCodeKey = "evmcode"
 )

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -5,5 +5,5 @@ const (
 	ModuleName = "ethermint"
 
 	EvmStoreKey = "evmstore"
-	EvmCodeKey = "evmcode"
+	EvmCodeKey  = "evmcode"
 )

--- a/x/evm/types/statedb.go
+++ b/x/evm/types/statedb.go
@@ -82,7 +82,7 @@ type CommitStateDB struct {
 //
 // CONTRACT: Stores used for state must be cache-wrapped as the ordering of the
 // key/value space matters in determining the merkle root.
-func NewCommitStateDB(ctx sdk.Context, ak auth.AccountKeeper, storageKey, codeKey sdk.StoreKey) (*CommitStateDB, error) {
+func NewCommitStateDB(ctx sdk.Context, ak auth.AccountKeeper, storageKey, codeKey sdk.StoreKey) *CommitStateDB {
 	return &CommitStateDB{
 		ctx:               ctx,
 		ak:                ak,
@@ -93,7 +93,12 @@ func NewCommitStateDB(ctx sdk.Context, ak auth.AccountKeeper, storageKey, codeKe
 		logs:              make(map[ethcmn.Hash][]*ethtypes.Log),
 		preimages:         make(map[ethcmn.Hash][]byte),
 		journal:           newJournal(),
-	}, nil
+	}
+}
+
+func (csdb *CommitStateDB) WithContext(ctx sdk.Context) *CommitStateDB {
+	csdb.ctx = ctx
+	return csdb
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
- Implements `Keeper`. This is a wrapper around the "real" keeper (CSDB). Since we need to pass the context into the keeper we need to abstract the CSDB from the keeper. 
- Adds `WithContext()` to CSDB to support the above requirement
- Adds Keeper to app
