### PR TITLE
Update App AnteHandler

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -173,6 +173,10 @@ func consumeSigGas(meter sdk.GasMeter, pubkey tmcrypto.PubKey) {
 	switch pubkey.(type) {
 	case crypto.PubKeySecp256k1:
 		meter.ConsumeGas(secp256k1VerifyCost, "ante verify: secp256k1")
+	// TODO: Remove allowing tm Pub key to sign transactions (if intended in final release)
+	// or until genesis utils are built into the evm or as their own module
+	case tmcrypto.PubKey:
+		meter.ConsumeGas(secp256k1VerifyCost, "ante verify: tendermint secp256k1")
 	default:
 		panic("Unrecognized signature type")
 	}

--- a/app/ethermint.go
+++ b/app/ethermint.go
@@ -217,7 +217,7 @@ func NewEthermintApp(
 	// initialize BaseApp
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
-	app.SetAnteHandler(auth.NewAnteHandler(app.accountKeeper, app.supplyKeeper, auth.DefaultSigVerificationGasConsumer))
+	app.SetAnteHandler(NewAnteHandler(app.accountKeeper, app.supplyKeeper))
 	app.SetEndBlocker(app.EndBlocker)
 
 	if loadLatest {


### PR DESCRIPTION
- Changes from default antehandler to AnteHandler that was built for ethereum transactions
- Adds a temporary measure of allowing tendermint Key to sign genesis transactions to be able to fund a validator to start the node to not have to build out #81 as it is out of the scope of the current work
- Allows the gas consumption logic to be included and usable when implementing the other functionality of an Ethereum transaction within the CosmosSDK handler framework for a tx

This includes the functionality of the Application previously, allowing the previous flow for starting the app, for example as so:

```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id testchain
emintcli config chain-id testchain
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli keys add austin
<password>
<password>
emintd add-genesis-account $(emintcli keys show austin -a) 1000photon,100000000stake
emintd gentx --name austin
<password>
emintd collect-gentxs
emintd validate-genesis
emintd start
```

Implements #71, and I will create an issue to remove the workaround for the genesis tx and find a solution that is compatible for anyone using the evm module.