### PR TITLE
Implements eth_getBlockTransactionCountByNumber

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -114,13 +114,19 @@ func (e *PublicEthAPI) GetBlockTransactionCountByHash(hash common.Hash) hexutil.
 }
 
 // GetBlockTransactionCountByNumber returns the number of transactions in the block identified by number.
-func (e *PublicEthAPI) GetBlockTransactionCountByNumber(blockNum rpc.BlockNumber) hexutil.Uint {
-	node, _ := e.cliCtx.GetNode()
+func (e *PublicEthAPI) GetBlockTransactionCountByNumber(blockNum rpc.BlockNumber) (hexutil.Uint, error) {
+	node, err := e.cliCtx.GetNode()
+	if err != nil {
+		return 0, err
+	}
 
 	height := blockNum.Int64()
-	block, _ := node.Block(&height)
+	block, err := node.Block(&height)
+	if err != nil {
+		return 0, err
+	}
 
-	return hexutil.Uint(block.Block.NumTxs)
+	return hexutil.Uint(block.Block.NumTxs), nil
 }
 
 // GetUncleCountByBlockHash returns the number of uncles in the block idenfied by hash. Always zero.

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -115,7 +115,12 @@ func (e *PublicEthAPI) GetBlockTransactionCountByHash(hash common.Hash) hexutil.
 
 // GetBlockTransactionCountByNumber returns the number of transactions in the block identified by number.
 func (e *PublicEthAPI) GetBlockTransactionCountByNumber(blockNum rpc.BlockNumber) hexutil.Uint {
-	return 0
+	node, _ := e.cliCtx.GetNode()
+
+	height := blockNum.Int64()
+	block, _ := node.Block(&height)
+
+	return hexutil.Uint(block.Block.NumTxs)
 }
 
 // GetUncleCountByBlockHash returns the number of uncles in the block idenfied by hash. Always zero.


### PR DESCRIPTION
- Completes #31 

This does not depend on the format of tx data or receipts so can be merged in now.

To test:
1. Run the Ethermint node how it is normally run, I ran:
```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id testchain
emintcli config chain-id testchain
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli keys add austin
<password>
<password>
emintd add-genesis-account $(emintcli keys show austin -a) 1000photon,100000000stake
emintd gentx --name austin
<password>
emintd collect-gentxs
emintd validate-genesis
emintd start
```

2. Start rest server:
```
emintcli rest-server --laddr "tcp://localhost:8545"
```

3. Send request:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByNumber","params":["0x1"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
 > {"jsonrpc":"2.0","id":1,"result":"0x0"}
```

Since txs can't be sent currently, it will always be 0, but I have tested with manual values that it correctly outputs other values if that is what is pulled from the TM node.