### PR TITLE
RPC error handling for implemented endpoints

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -76,31 +76,29 @@ func (e *PublicEthAPI) BlockNumber() *big.Int {
 }
 
 // GetBalance returns the provided account's balance up to the provided block number.
-func (e *PublicEthAPI) GetBalance(address common.Address, blockNum rpc.BlockNumber) *hexutil.Big {
+func (e *PublicEthAPI) GetBalance(address common.Address, blockNum rpc.BlockNumber) (*hexutil.Big, error) {
 	ctx := e.cliCtx.WithHeight(blockNum.Int64())
 	res, _, err := ctx.QueryWithData(fmt.Sprintf("custom/%s/balance/%s", types.ModuleName, address), nil)
 	if err != nil {
-		fmt.Printf("could not resolve: %s\n", err)
-		return nil
+		return nil, err
 	}
 
 	var out types.QueryResBalance
 	e.cliCtx.Codec.MustUnmarshalJSON(res, &out)
-	return (*hexutil.Big)(out.Balance)
+	return (*hexutil.Big)(out.Balance), nil
 }
 
 // GetStorageAt returns the contract storage at the given address, block number, and key.
-func (e *PublicEthAPI) GetStorageAt(address common.Address, key string, blockNum rpc.BlockNumber) hexutil.Bytes {
+func (e *PublicEthAPI) GetStorageAt(address common.Address, key string, blockNum rpc.BlockNumber) (hexutil.Bytes, error) {
 	ctx := e.cliCtx.WithHeight(blockNum.Int64())
 	res, _, err := ctx.QueryWithData(fmt.Sprintf("custom/%s/storage/%s/%s", types.ModuleName, address, key), nil)
 	if err != nil {
-		fmt.Printf("could not resolve: %s\n", err)
-		return nil
+		return nil, err
 	}
 
 	var out types.QueryResStorage
 	e.cliCtx.Codec.MustUnmarshalJSON(res, &out)
-	return out.Value[:]
+	return out.Value[:], nil
 }
 
 // GetTransactionCount returns the number of transactions at the given address up to the given block number.
@@ -129,17 +127,16 @@ func (e *PublicEthAPI) GetUncleCountByBlockNumber(blockNum rpc.BlockNumber) hexu
 }
 
 // GetCode returns the contract code at the given address and block number.
-func (e *PublicEthAPI) GetCode(address common.Address, blockNumber rpc.BlockNumber) hexutil.Bytes {
+func (e *PublicEthAPI) GetCode(address common.Address, blockNumber rpc.BlockNumber) (hexutil.Bytes, error) {
 	ctx := e.cliCtx.WithHeight(blockNumber.Int64())
 	res, _, err := ctx.QueryWithData(fmt.Sprintf("custom/%s/code/%s", types.ModuleName, address), nil)
 	if err != nil {
-		fmt.Printf("could not resolve: %s\n", err)
-		return nil
+		return nil, err
 	}
 
 	var out types.QueryResCode
 	e.cliCtx.Codec.MustUnmarshalJSON(res, &out)
-	return out.Code
+	return out.Code, nil
 }
 
 // Sign signs the provided data using the private key of address via Geth's signature standard.


### PR DESCRIPTION
Error logs are not output through the API process and are ignored in execution. This adds error handling to the three endpoints which sends the error back as the response to the client

Through this I have found that:

1. Historical queries aren't actually functional as of now (it was implied that specifying height to ABCI query would query state at that height):

```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b","0x2"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
 > {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"{\"codespace\":\"sdk\",\"code\":1,\"message\":\"failed to load state at height 2; version does not exist (latest height: 3)\"}"}}
```

2. There was an error retrieving the state (possibly due to state transition but I won't explore further right now):

```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b","0x2"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
 > {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"ABCIQuery: response error: RPC error -32603 - Internal error: runtime error: invalid memory address or nil pointer dereference"}}
```

Error log on daemon process:

```
E[2019-08-30|16:25:39.267] Panic in RPC HTTP handler                    module=rpc-server err="runtime error: invalid memory address or nil pointer dereference" stack="goroutine 138 [running]:\nruntime/debug.Stack(0xc000bfdb20, 0x4d25ba0, 0x5c33690)\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x9d\ngithub.com/tendermint/tendermint/rpc/lib/server.RecoverAndLogHandler.func1.1(0xc002231180, 0x529bde0, 0xc000a92dc0, 0xbf527f70cfd6f650, 0x2e8b4d49e, 0x5c4fb20, 0xc000bccf00)\n\t/Users/austinabell/go/pkg/mod/github.com/tendermint/tendermint@v0.32.2/rpc/lib/server/http_server.go:161 +0x552\npanic(0x4d25ba0, 0x5c33690)\n\t/usr/local/go/src/runtime/panic.go:522 +0x1b5\ngithub.com/cosmos/ethermint/x/evm/types.(*CommitStateDB).WithContext(...)\n\t/Users/austinabell/development/github.com/chainsafe/ethermint/x/evm/types/statedb.go:100\ngithub.com/cosmos/ethermint/x/evm.(*Keeper).GetCode(...)\n\t/Users/austinabell/development/github.com/chainsafe/ethermint/x/evm/keeper.go:126\ngithub.com/cosmos/ethermint/x/evm.queryCode(0x529b2a0, 0xc0000b6008, 0x52adbe0, 0xc000b6bc00, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/Users/austinabell/development/github.com/chainsafe/ethermint/x/evm/querier.go:97 +0x165\ngithub.com/cosmos/ethermint/x/evm.NewQuerier.func1(0x529b2a0, 0xc0000b6008, 0x52adbe0, 0xc000b6bc00, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/Users/austinabell/development/github.com/chainsafe/ethermint/x/evm/querier.go:36 +0x230\ngithub.com/cosmos/cosmos-sdk/baseapp.handleQueryCustom(0xc000142b40, 0xc000b6bbc0, 0x4, 0x4, 0x5c7b1a0, 0x0, 0x0, 0xc002223e00, 0x3e, 0x2, ...)\n\t/Users/austinabell/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.36.0/baseapp/baseapp.go:588 +0x5b3\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Query(0xc000142b40, 0x5c7b1a0, 0x0, 0x0, 0xc002223e00, 0x3e, 0x2, 0x0, 0x0, 0x0, ...)\n\t/Users/austinabell/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.36.0/baseapp/baseapp.go:463 +0x2e9\ngithub.com/tendermint/tendermint/abci/client.(*localClient).QuerySync(0xc0000c7800, 0x5c7b1a0, 0x0, 0x0, 0xc002223e00, 0x3e, 0x2, 0x0, 0x0, 0x0, ...)\n\t/Users/austinabell/go/pkg/mod/github.com/tendermint/tendermint@v0.32.2/abci/client/local_client.go:207 +0xf3\ngithub.com/tendermint/tendermint/proxy.(*appConnQuery).QuerySync(0xc000b7eee0, 0x5c7b1a0, 0x0, 0x0, 0xc002223e00, 0x3e, 0x2, 0x0, 0x0, 0x0, ...)\n\t/Users/austinabell/go/pkg/mod/github.com/tendermint/tendermint@v0.32.2/proxy/app_conn.go:143 +0x6d\ngithub.com/tendermint/tendermint/rpc/core.ABCIQuery(0xc0022311c0, 0xc002223e00, 0x3e, 0x5c7b1a0, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, ...)\n\t/Users/austinabell/go/pkg/mod/github.com/tendermint/tendermint@v0.32.2/rpc/core/abci.go:57 +0x114\nreflect.Value.call(0x4d3d2c0, 0x508bc78, 0x13, 0x4e8d19e, 0x4, 0xc000399e80, 0x5, 0x5, 0x5, 0xc000399e80, ...)\n\t/usr/local/go/src/reflect/value.go:447 +0x461\nreflect.Value.Call(0x4d3d2c0, 0x508bc78, 0x13, 0xc000399e80, 0x5, 0x5, 0x4, 0x4, 0x0)\n\t/usr/local/go/src/reflect/value.go:308 +0xa4\ngithub.com/tendermint/tendermint/rpc/lib/server.makeJSONRPCHandler.func1(0x52959a0, 0xc002231180, 0xc000bccf00)\n\t/Users/austinabell/go/pkg/mod/github.com/tendermint/tendermint@v0.32.2/rpc/lib/server/handlers.go:157 +0x90a\ngithub.com/tendermint/tendermint/rpc/lib/server.handleInvalidJSONRPCPaths.func1(0x52959a0, 0xc002231180, 0xc000bccf00)\n\t/Users/austinabell/go/pkg/mod/github.com/tendermint/tendermint@v0.32.2/rpc/lib/server/handlers.go:181 +0x9c\nnet/http.HandlerFunc.ServeHTTP(0xc000b045e0, 0x52959a0, 0xc002231180, 0xc000bccf00)\n\t/usr/local/go/src/net/http/server.go:1995 +0x44\nnet/http.(*ServeMux).ServeHTTP(0xc000b6a2c0, 0x52959a0, 0xc002231180, 0xc000bccf00)\n\t/usr/local/go/src/net/http/server.go:2375 +0x1d6\ngithub.com/tendermint/tendermint/rpc/lib/server.maxBytesHandler.ServeHTTP(0x527b740, 0xc000b6a2c0, 0xf4240, 0x52959a0, 0xc002231180, 0xc000bccf00)\n\t/Users/austinabell/go/pkg/mod/github.com/tendermint/tendermint@v0.32.2/rpc/lib/server/http_server.go:206 +0xd0\ngithub.com/tendermint/tendermint/rpc/lib/server.RecoverAndLogHandler.func1(0x52960a0, 0xc0000fcc40, 0xc000bccf00)\n\t/Users/austinabell/go/pkg/mod/github.com/tendermint/tendermint@v0.32.2/rpc/lib/server/http_server.go:179 +0x317\nnet/http.HandlerFunc.ServeHTTP(0xc000bd5c50, 0x52960a0, 0xc0000fcc40, 0xc000bccf00)\n\t/usr/local/go/src/net/http/server.go:1995 +0x44\nnet/http.serverHandler.ServeHTTP(0xc000979450, 0x52960a0, 0xc0000fcc40, 0xc000bccf00)\n\t/usr/local/go/src/net/http/server.go:2774 +0xa8\nnet/http.(*conn).serve(0xc000bb8000, 0x529b260, 0xc000b6a380)\n\t/usr/local/go/src/net/http/server.go:1878 +0x851\ncreated by net/http.(*Server).Serve\n\t/usr/local/go/src/net/http/server.go:2884 +0x2f4\n"
```