### PR TITLE
eth_getTransactionCount implementation

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -102,8 +102,16 @@ func (e *PublicEthAPI) GetStorageAt(address common.Address, key string, blockNum
 }
 
 // GetTransactionCount returns the number of transactions at the given address up to the given block number.
-func (e *PublicEthAPI) GetTransactionCount(address common.Address, blockNum rpc.BlockNumber) hexutil.Uint64 {
-	return 0
+func (e *PublicEthAPI) GetTransactionCount(address common.Address, blockNum rpc.BlockNumber) (hexutil.Uint64, error) {
+	ctx := e.cliCtx.WithHeight(blockNum.Int64())
+	res, _, err := ctx.QueryWithData(fmt.Sprintf("custom/%s/nonce/%s", types.ModuleName, address), nil)
+	if err != nil {
+		return 0, err
+	}
+
+	var out types.QueryResNonce
+	e.cliCtx.Codec.MustUnmarshalJSON(res, &out)
+	return hexutil.Uint64(out.Nonce), nil
 }
 
 // GetBlockTransactionCountByHash returns the number of transactions in the block identified by hash.

--- a/x/evm/querier.go
+++ b/x/evm/querier.go
@@ -1,6 +1,8 @@
 package evm
 
 import (
+	"math/big"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/ethermint/version"
@@ -8,7 +10,6 @@ import (
 	ethcmn "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	abci "github.com/tendermint/tendermint/abci/types"
-	"math/big"
 )
 
 // Supported endpoints
@@ -18,6 +19,7 @@ const (
 	QueryBlockNumber     = "blockNumber"
 	QueryStorage         = "storage"
 	QueryCode            = "code"
+	QueryNonce           = "nonce"
 )
 
 // NewQuerier is the module level router for state queries
@@ -34,6 +36,8 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return queryStorage(ctx, path, keeper)
 		case QueryCode:
 			return queryCode(ctx, path, keeper)
+		case QueryNonce:
+			return queryNonce(ctx, path, keeper)
 		default:
 			return nil, sdk.ErrUnknownRequest("unknown query endpoint")
 		}
@@ -97,6 +101,18 @@ func queryCode(ctx sdk.Context, path []string, keeper Keeper) ([]byte, sdk.Error
 	code := keeper.GetCode(ctx, addr)
 	cRes := types.QueryResCode{Code: code}
 	res, err := codec.MarshalJSONIndent(keeper.cdc, cRes)
+	if err != nil {
+		panic("could not marshal result to JSON")
+	}
+
+	return res, nil
+}
+
+func queryNonce(ctx sdk.Context, path []string, keeper Keeper) ([]byte, sdk.Error) {
+	addr := ethcmn.BytesToAddress([]byte(path[1]))
+	nonce := keeper.GetNonce(ctx, addr)
+	nRes := types.QueryResNonce{Nonce: nonce}
+	res, err := codec.MarshalJSONIndent(keeper.cdc, nRes)
 	if err != nil {
 		panic("could not marshal result to JSON")
 	}

--- a/x/evm/types/querier.go
+++ b/x/evm/types/querier.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type QueryResProtocolVersion struct {
@@ -43,4 +44,12 @@ type QueryResCode struct {
 
 func (q QueryResCode) String() string {
 	return string(q.Code)
+}
+
+type QueryResNonce struct {
+	Nonce uint64 `json:"result"`
+}
+
+func (q QueryResNonce) String() string {
+	return q.String()
 }

--- a/x/evm/types/querier.go
+++ b/x/evm/types/querier.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+// QueryResProtocolVersion is response type for protocol version query
 type QueryResProtocolVersion struct {
 	Version string `json:"result"`
 }
@@ -14,6 +15,7 @@ func (q QueryResProtocolVersion) String() string {
 	return q.Version
 }
 
+// QueryResBalance is response type for balance query
 type QueryResBalance struct {
 	Balance *hexutil.Big `json:"result"`
 }
@@ -22,6 +24,7 @@ func (q QueryResBalance) String() string {
 	return q.Balance.String()
 }
 
+// QueryResBlockNumber is response type for block number query
 type QueryResBlockNumber struct {
 	Number *big.Int `json:"result"`
 }
@@ -30,6 +33,7 @@ func (q QueryResBlockNumber) String() string {
 	return q.Number.String()
 }
 
+// QueryResStorage is response type for storage query
 type QueryResStorage struct {
 	Value []byte `json:"value"`
 }
@@ -38,6 +42,7 @@ func (q QueryResStorage) String() string {
 	return string(q.Value)
 }
 
+// QueryResCode is response type for code query
 type QueryResCode struct {
 	Code []byte
 }
@@ -46,10 +51,11 @@ func (q QueryResCode) String() string {
 	return string(q.Code)
 }
 
+// QueryResNonce is response type for Nonce query
 type QueryResNonce struct {
 	Nonce uint64 `json:"result"`
 }
 
 func (q QueryResNonce) String() string {
-	return q.String()
+	return string(q.Nonce)
 }


### PR DESCRIPTION
- Implements #29 

Currently runs into same issue as previous methods, indicated with #89 so this can be merged in and all of the issues can be handled at once or this can be left and the fix can be included in this PR

To test:
1. Run the Ethermint node how it is normally run, I ran:
```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id testchain
emintcli config chain-id testchain
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli keys add austin
<password>
<password>
emintd add-genesis-account $(emintcli keys show austin -a) 1000photon,100000000stake
emintd gentx --name austin
<password>
emintd collect-gentxs
emintd validate-genesis
emintd start --pruning=nothing
```

2. Start rest server
```
emintcli rest-server --laddr "tcp://localhost:8545"
```

3. Send request:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0xc94770007dda54cF92009BFF0dE90c06F603a09f","0x2"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
```

Historical queries still not available even with pruning flag and errors on current block