### PR TITLE
EVM Transaction handler and contract creation

### DIFF
--- a/app/ethermint.go
+++ b/app/ethermint.go
@@ -80,6 +80,8 @@ func MakeCodec() *codec.Codec {
 	ModuleBasics.RegisterCodec(cdc)
 	sdk.RegisterCodec(cdc)
 	codec.RegisterCrypto(cdc)
+	eminttypes.RegisterCodec(cdc)
+
 	return cdc
 }
 

--- a/app/ethermint.go
+++ b/app/ethermint.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	"github.com/cosmos/cosmos-sdk/x/supply"
 
+	eminttypes "github.com/cosmos/ethermint/types"
 	evmtypes "github.com/cosmos/ethermint/x/evm/types"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -128,7 +129,7 @@ func NewEthermintApp(
 
 	keys := sdk.NewKVStoreKeys(bam.MainStoreKey, auth.StoreKey, staking.StoreKey,
 		supply.StoreKey, mint.StoreKey, distr.StoreKey, slashing.StoreKey,
-		gov.StoreKey, params.StoreKey)
+		gov.StoreKey, params.StoreKey, evmtypes.EvmStoreKey, evmtypes.EvmCodeKey)
 	tkeys := sdk.NewTransientStoreKeys(staking.TStoreKey, params.TStoreKey)
 
 	app := &EthermintApp{
@@ -151,7 +152,7 @@ func NewEthermintApp(
 	crisisSubspace := app.paramsKeeper.Subspace(crisis.DefaultParamspace)
 
 	// add keepers
-	app.accountKeeper = auth.NewAccountKeeper(app.cdc, keys[auth.StoreKey], authSubspace, auth.ProtoBaseAccount)
+	app.accountKeeper = auth.NewAccountKeeper(app.cdc, keys[auth.StoreKey], authSubspace, eminttypes.ProtoBaseAccount)
 	app.bankKeeper = bank.NewBaseKeeper(app.accountKeeper, bankSubspace, bank.DefaultCodespace, app.ModuleAccountAddrs())
 	app.supplyKeeper = supply.NewKeeper(app.cdc, keys[supply.StoreKey], app.accountKeeper, app.bankKeeper, maccPerms)
 	stakingKeeper := staking.NewKeeper(app.cdc, keys[staking.StoreKey], tkeys[staking.TStoreKey],
@@ -162,6 +163,7 @@ func NewEthermintApp(
 	app.slashingKeeper = slashing.NewKeeper(app.cdc, keys[slashing.StoreKey], &stakingKeeper,
 		slashingSubspace, slashing.DefaultCodespace)
 	app.crisisKeeper = crisis.NewKeeper(crisisSubspace, invCheckPeriod, app.supplyKeeper, auth.FeeCollectorName)
+	app.evmKeeper = evm.NewKeeper(app.accountKeeper, keys[evmtypes.EvmStoreKey], keys[evmtypes.EvmCodeKey], cdc)
 
 	// register the proposal types
 	govRouter := gov.NewRouter()
@@ -204,7 +206,7 @@ func NewEthermintApp(
 	app.mm.SetOrderInitGenesis(
 		genaccounts.ModuleName, distr.ModuleName, staking.ModuleName,
 		auth.ModuleName, bank.ModuleName, slashing.ModuleName, gov.ModuleName,
-		mint.ModuleName, supply.ModuleName, crisis.ModuleName, genutil.ModuleName,
+		mint.ModuleName, supply.ModuleName, crisis.ModuleName, genutil.ModuleName, evmtypes.ModuleName,
 	)
 
 	app.mm.RegisterInvariants(&app.crisisKeeper)

--- a/types/account.go
+++ b/types/account.go
@@ -28,8 +28,8 @@ type Account struct {
 
 	// merkle root of the storage trie
 	//
-	// TODO: good chance we may not need this
-	Root ethcmn.Hash
+	// TODO: add back root if needed (marshalling is broken if not initializing)
+	// Root ethcmn.Hash
 
 	CodeHash []byte
 }

--- a/types/account_retriever.go
+++ b/types/account_retriever.go
@@ -1,0 +1,75 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/exported"
+	auth "github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// ** Modified version of github.com/cosmos/cosmos-sdk/x/auth/types/account_retriever.go
+// ** to allow passing in a codec for decoding Account types
+// AccountRetriever defines the properties of a type that can be used to
+// retrieve accounts.
+type AccountRetriever struct {
+	querier auth.NodeQuerier
+	codec   *codec.Codec
+}
+
+// NewAccountRetriever initialises a new AccountRetriever instance.
+func NewAccountRetriever(context context.CLIContext, codec *codec.Codec) AccountRetriever {
+	if codec == nil {
+		codec = auth.ModuleCdc
+	}
+	return AccountRetriever{querier: context, codec: codec}
+}
+
+// GetAccount queries for an account given an address and a block height. An
+// error is returned if the query or decoding fails.
+func (ar AccountRetriever) GetAccount(addr sdk.AccAddress) (exported.Account, error) {
+	account, _, err := ar.GetAccountWithHeight(addr)
+	return account, err
+}
+
+// GetAccountWithHeight queries for an account given an address. Returns the
+// height of the query with the account. An error is returned if the query
+// or decoding fails.
+func (ar AccountRetriever) GetAccountWithHeight(addr sdk.AccAddress) (exported.Account, int64, error) {
+	bs, err := ar.codec.MarshalJSON(auth.NewQueryAccountParams(addr))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	res, height, err := ar.querier.QueryWithData(fmt.Sprintf("custom/%s/%s", auth.QuerierRoute, auth.QueryAccount), bs)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var account exported.Account
+	if err := ar.codec.UnmarshalJSON(res, &account); err != nil {
+		return nil, 0, err
+	}
+
+	return account, height, nil
+}
+
+// EnsureExists returns an error if no account exists for the given address else nil.
+func (ar AccountRetriever) EnsureExists(addr sdk.AccAddress) error {
+	if _, err := ar.GetAccount(addr); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetAccountNumberSequence returns sequence and account number for the given address.
+// It returns an error if the account couldn't be retrieved from the state.
+func (ar AccountRetriever) GetAccountNumberSequence(addr sdk.AccAddress) (uint64, uint64, error) {
+	acc, err := ar.GetAccount(addr)
+	if err != nil {
+		return 0, 0, err
+	}
+	return acc.GetAccountNumber(), acc.GetSequence(), nil
+}

--- a/types/account_retriever.go
+++ b/types/account_retriever.go
@@ -3,7 +3,6 @@ package types
 import (
 	"fmt"
 
-	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/exported"
@@ -19,12 +18,13 @@ type AccountRetriever struct {
 	codec   *codec.Codec
 }
 
+// * Modified to allow a codec to be passed in
 // NewAccountRetriever initialises a new AccountRetriever instance.
-func NewAccountRetriever(context context.CLIContext, codec *codec.Codec) AccountRetriever {
+func NewAccountRetriever(querier auth.NodeQuerier, codec *codec.Codec) AccountRetriever {
 	if codec == nil {
 		codec = auth.ModuleCdc
 	}
-	return AccountRetriever{querier: context, codec: codec}
+	return AccountRetriever{querier: querier, codec: codec}
 }
 
 // GetAccount queries for an account given an address and a block height. An
@@ -38,6 +38,7 @@ func (ar AccountRetriever) GetAccount(addr sdk.AccAddress) (exported.Account, er
 // height of the query with the account. An error is returned if the query
 // or decoding fails.
 func (ar AccountRetriever) GetAccountWithHeight(addr sdk.AccAddress) (exported.Account, int64, error) {
+	// ** This line was changed to use non-static codec
 	bs, err := ar.codec.MarshalJSON(auth.NewQueryAccountParams(addr))
 	if err != nil {
 		return nil, 0, err
@@ -49,6 +50,7 @@ func (ar AccountRetriever) GetAccountWithHeight(addr sdk.AccAddress) (exported.A
 	}
 
 	var account exported.Account
+	// ** This line was changed to use non-static codec
 	if err := ar.codec.UnmarshalJSON(res, &account); err != nil {
 		return nil, 0, err
 	}

--- a/types/errors.go
+++ b/types/errors.go
@@ -41,12 +41,12 @@ func ErrInvalidChainID(msg string) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeInvalidChainID, msg)
 }
 
-// ErrInvalidSender returns a standardized SDK error resulting from an invalid transaction sender
+// ErrInvalidSender returns a standardized SDK error resulting from an invalid transaction sender.
 func ErrInvalidSender(msg string) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeInvalidSender, msg)
 }
 
-// ErrInvalidSender returns a standardized SDK error resulting from an invalid transaction sender
+// ErrVMExecution returns a standardized SDK error resulting from an error in EVM execution.
 func ErrVMExecution(msg string) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeVMExecution, msg)
 }

--- a/types/errors.go
+++ b/types/errors.go
@@ -11,6 +11,8 @@ const (
 
 	CodeInvalidValue   sdk.CodeType = 1
 	CodeInvalidChainID sdk.CodeType = 2
+	CodeInvalidSender  sdk.CodeType = 3
+	CodeVMExecution    sdk.CodeType = 4
 )
 
 // CodeToDefaultMsg takes the CodeType variable and returns the error string
@@ -20,19 +22,31 @@ func CodeToDefaultMsg(code sdk.CodeType) string {
 		return "invalid value"
 	case CodeInvalidChainID:
 		return "invalid chain ID"
+	case CodeInvalidSender:
+		return "could not derive sender from transaction"
+	case CodeVMExecution:
+		return "error while executing evm transaction"
 	default:
 		return sdk.CodeToDefaultMsg(code)
 	}
 }
 
-// ErrInvalidValue returns a standardized SDK error resulting from an invalid
-// value.
+// ErrInvalidValue returns a standardized SDK error resulting from an invalid value.
 func ErrInvalidValue(msg string) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeInvalidValue, msg)
 }
 
-// ErrInvalidChainID returns a standardized SDK error resulting from an invalid
-// chain ID.
+// ErrInvalidChainID returns a standardized SDK error resulting from an invalid chain ID.
 func ErrInvalidChainID(msg string) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeInvalidChainID, msg)
+}
+
+// ErrInvalidSender returns a standardized SDK error resulting from an invalid transaction sender
+func ErrInvalidSender(msg string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidSender, msg)
+}
+
+// ErrInvalidSender returns a standardized SDK error resulting from an invalid transaction sender
+func ErrVMExecution(msg string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeVMExecution, msg)
 }

--- a/types/errors.go
+++ b/types/errors.go
@@ -9,10 +9,11 @@ const (
 	// DefaultCodespace reserves a Codespace for Ethermint.
 	DefaultCodespace sdk.CodespaceType = "ethermint"
 
-	CodeInvalidValue   sdk.CodeType = 1
-	CodeInvalidChainID sdk.CodeType = 2
-	CodeInvalidSender  sdk.CodeType = 3
-	CodeVMExecution    sdk.CodeType = 4
+	CodeInvalidValue        sdk.CodeType = 1
+	CodeInvalidChainID      sdk.CodeType = 2
+	CodeInvalidSender       sdk.CodeType = 3
+	CodeVMExecution         sdk.CodeType = 4
+	CodeInvalidIntrinsicGas sdk.CodeType = 5
 )
 
 // CodeToDefaultMsg takes the CodeType variable and returns the error string
@@ -26,6 +27,8 @@ func CodeToDefaultMsg(code sdk.CodeType) string {
 		return "could not derive sender from transaction"
 	case CodeVMExecution:
 		return "error while executing evm transaction"
+	case CodeInvalidIntrinsicGas:
+		return "invalid intrinsic gas"
 	default:
 		return sdk.CodeToDefaultMsg(code)
 	}
@@ -49,4 +52,9 @@ func ErrInvalidSender(msg string) sdk.Error {
 // ErrVMExecution returns a standardized SDK error resulting from an error in EVM execution.
 func ErrVMExecution(msg string) sdk.Error {
 	return sdk.NewError(DefaultCodespace, CodeVMExecution, msg)
+}
+
+// ErrVMExecution returns a standardized SDK error resulting from an error in EVM execution.
+func ErrInvalidIntrinsicGas(msg string) sdk.Error {
+	return sdk.NewError(DefaultCodespace, CodeInvalidIntrinsicGas, msg)
 }

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -88,9 +88,9 @@ func GetCmdGenTx(cdc *codec.Codec) *cobra.Command {
 // GetCmdGenTx generates an ethereum transaction
 func GetCmdGenETHTx(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "generate-eth-tx [ethaddress] [amount] [gaslimit] [gasprice] [payload]",
-		Short: "geberate and broadcast an Ethereum tx",
-		Args:  cobra.ExactArgs(5),
+		Use:   "generate-eth-tx [amount] [gaslimit] [gasprice] [payload] [<ethereum-address>]",
+		Short: "generate and broadcast an Ethereum tx. If address is not specified, contract will be created",
+		Args:  cobra.RangeArgs(4, 5),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := emintUtils.NewETHCLIContext().WithCodec(cdc)
 
@@ -106,29 +106,35 @@ func GetCmdGenETHTx(cdc *codec.Codec) *cobra.Command {
 			// 	return err
 			// }
 
-			coins, err := sdk.ParseCoins(args[1])
+			coins, err := sdk.ParseCoins(args[0])
 			if err != nil {
 				return err
 			}
 
-			gasLimit, err := strconv.ParseUint(args[2], 0, 64)
+			gasLimit, err := strconv.ParseUint(args[1], 0, 64)
 			if err != nil {
 				return err
 			}
 
-			gasPrice, err := strconv.ParseUint(args[3], 0, 64)
+			gasPrice, err := strconv.ParseUint(args[2], 0, 64)
 			if err != nil {
 				return err
 			}
 
-			payload := args[4]
+			payload := args[3]
 
 			txBldr, err = emintUtils.PrepareTxBuilder(txBldr, cliCtx)
 			if err != nil {
 				return err
 			}
 
-			tx := types.NewEthereumTxMsg(txBldr.Sequence(), ethcmn.HexToAddress(args[0]), big.NewInt(coins.AmountOf(emintTypes.DenomDefault).Int64()), gasLimit, new(big.Int).SetUint64(gasPrice), []byte(payload))
+			var tx *types.EthereumTxMsg
+			if len(args) == 5 {
+				tx = types.NewEthereumTxMsg(txBldr.Sequence(), ethcmn.HexToAddress(args[4]), big.NewInt(coins.AmountOf(emintTypes.DenomDefault).Int64()), gasLimit, new(big.Int).SetUint64(gasPrice), []byte(payload))
+			} else {
+				tx = types.NewEthereumTxMsgContract(txBldr.Sequence(), big.NewInt(coins.AmountOf(emintTypes.DenomDefault).Int64()), gasLimit, new(big.Int).SetUint64(gasPrice), []byte(payload))
+			}
+
 			err = tx.ValidateBasic()
 			if err != nil {
 				return err

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -123,6 +123,11 @@ func GetCmdGenETHTx(cdc *codec.Codec) *cobra.Command {
 
 			payload := args[4]
 
+			txBldr, err = emintUtils.PrepareTxBuilder(txBldr, cliCtx)
+			if err != nil {
+				return err
+			}
+
 			tx := types.NewEthereumTxMsg(txBldr.Sequence(), ethcmn.HexToAddress(args[0]), big.NewInt(coins.AmountOf(emintTypes.DenomDefault).Int64()), gasLimit, new(big.Int).SetUint64(gasPrice), []byte(payload))
 			err = tx.ValidateBasic()
 			if err != nil {

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -101,11 +101,6 @@ func GetCmdGenETHTx(cdc *codec.Codec) *cobra.Command {
 				panic(err)
 			}
 
-			// nonce, err := strconv.ParseUint(args[0], 0, 64)
-			// if err != nil {
-			// 	return err
-			// }
-
 			coins, err := sdk.ParseCoins(args[0])
 			if err != nil {
 				return err

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -88,9 +88,9 @@ func GetCmdGenTx(cdc *codec.Codec) *cobra.Command {
 // GetCmdGenTx generates an ethereum transaction
 func GetCmdGenETHTx(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "generate-eth-tx [nonce] [ethaddress] [amount] [gaslimit] [gasprice] [payload]",
+		Use:   "generate-eth-tx [ethaddress] [amount] [gaslimit] [gasprice] [payload]",
 		Short: "geberate and broadcast an Ethereum tx",
-		Args:  cobra.ExactArgs(6),
+		Args:  cobra.ExactArgs(5),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := emintUtils.NewETHCLIContext().WithCodec(cdc)
 
@@ -101,35 +101,35 @@ func GetCmdGenETHTx(cdc *codec.Codec) *cobra.Command {
 				panic(err)
 			}
 
-			nonce, err := strconv.ParseUint(args[0], 0, 64)
+			// nonce, err := strconv.ParseUint(args[0], 0, 64)
+			// if err != nil {
+			// 	return err
+			// }
+
+			coins, err := sdk.ParseCoins(args[1])
 			if err != nil {
 				return err
 			}
 
-			coins, err := sdk.ParseCoins(args[2])
+			gasLimit, err := strconv.ParseUint(args[2], 0, 64)
 			if err != nil {
 				return err
 			}
 
-			gasLimit, err := strconv.ParseUint(args[3], 0, 64)
+			gasPrice, err := strconv.ParseUint(args[3], 0, 64)
 			if err != nil {
 				return err
 			}
 
-			gasPrice, err := strconv.ParseUint(args[4], 0, 64)
-			if err != nil {
-				return err
-			}
+			payload := args[4]
 
-			payload := args[5]
-
-			tx := types.NewEthereumTxMsg(nonce, ethcmn.HexToAddress(args[1]), big.NewInt(coins.AmountOf(emintTypes.DenomDefault).Int64()), gasLimit, new(big.Int).SetUint64(gasPrice), []byte(payload))
+			tx := types.NewEthereumTxMsg(txBldr.Sequence(), ethcmn.HexToAddress(args[0]), big.NewInt(coins.AmountOf(emintTypes.DenomDefault).Int64()), gasLimit, new(big.Int).SetUint64(gasPrice), []byte(payload))
 			err = tx.ValidateBasic()
 			if err != nil {
 				return err
 			}
 
-			return emintUtils.BroadcastETHTx(cliCtx, txBldr.WithSequence(nonce).WithKeybase(kb), tx)
+			return emintUtils.BroadcastETHTx(cliCtx, txBldr.WithKeybase(kb), tx)
 		},
 	}
 }

--- a/x/evm/client/utils/tx.go
+++ b/x/evm/client/utils/tx.go
@@ -42,10 +42,6 @@ func GenerateOrBroadcastETHMsgs(cliCtx context.CLIContext, txBldr authtypes.TxBu
 
 // BroadcastETHTx Broadcasts an Ethereum Tx not wrapped in a Std Tx
 func BroadcastETHTx(cliCtx context.CLIContext, txBldr authtypes.TxBuilder, tx *evmtypes.EthereumTxMsg) error {
-	txBldr, err := prepareTxBuilder(txBldr, cliCtx)
-	if err != nil {
-		return err
-	}
 
 	fromName := cliCtx.GetFromName()
 
@@ -347,8 +343,9 @@ func getFromFields(from string, genOnly bool) (sdk.AccAddress, string, error) {
 	return info.GetAddress(), info.GetName(), nil
 }
 
+// * Overriden function from cosmos-sdk/auth/client/utils/tx.go
 // PrepareTxBuilder populates a TxBuilder in preparation for the build of a Tx.
-func prepareTxBuilder(txBldr authtypes.TxBuilder, cliCtx context.CLIContext) (authtypes.TxBuilder, error) {
+func PrepareTxBuilder(txBldr authtypes.TxBuilder, cliCtx context.CLIContext) (authtypes.TxBuilder, error) {
 	from := cliCtx.GetFromAddress()
 
 	// * Function is needed to override to use different account getter (to not use static codec)

--- a/x/evm/client/utils/tx.go
+++ b/x/evm/client/utils/tx.go
@@ -42,7 +42,7 @@ func GenerateOrBroadcastETHMsgs(cliCtx context.CLIContext, txBldr authtypes.TxBu
 
 // BroadcastETHTx Broadcasts an Ethereum Tx not wrapped in a Std Tx
 func BroadcastETHTx(cliCtx context.CLIContext, txBldr authtypes.TxBuilder, tx *evmtypes.EthereumTxMsg) error {
-	txBldr, err := utils.PrepareTxBuilder(txBldr, cliCtx)
+	txBldr, err := prepareTxBuilder(txBldr, cliCtx)
 	if err != nil {
 		return err
 	}
@@ -345,4 +345,34 @@ func getFromFields(from string, genOnly bool) (sdk.AccAddress, string, error) {
 	}
 
 	return info.GetAddress(), info.GetName(), nil
+}
+
+// PrepareTxBuilder populates a TxBuilder in preparation for the build of a Tx.
+func prepareTxBuilder(txBldr authtypes.TxBuilder, cliCtx context.CLIContext) (authtypes.TxBuilder, error) {
+	from := cliCtx.GetFromAddress()
+
+	// * Function is needed to override to use different account getter (to not use static codec)
+	accGetter := emint.NewAccountRetriever(cliCtx, cliCtx.Codec)
+	if err := accGetter.EnsureExists(from); err != nil {
+		return txBldr, err
+	}
+
+	txbldrAccNum, txbldrAccSeq := txBldr.AccountNumber(), txBldr.Sequence()
+	// TODO: (ref #1903) Allow for user supplied account number without
+	// automatically doing a manual lookup.
+	if txbldrAccNum == 0 || txbldrAccSeq == 0 {
+		num, seq, err := accGetter.GetAccountNumberSequence(from)
+		if err != nil {
+			return txBldr, err
+		}
+
+		if txbldrAccNum == 0 {
+			txBldr = txBldr.WithAccountNumber(num)
+		}
+		if txbldrAccSeq == 0 {
+			txBldr = txBldr.WithSequence(seq)
+		}
+	}
+
+	return txBldr, nil
 }

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -3,6 +3,7 @@ package evm
 import (
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -61,8 +62,8 @@ func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk
 		Origin:      sender,
 		Coinbase:    common.Address{},
 		BlockNumber: big.NewInt(ctx.BlockHeight()),
-		Time:        new(big.Int).SetUint64(5), // unused
-		Difficulty:  big.NewInt(0x30000),       // unused
+		Time:        big.NewInt(time.Now().Unix()),
+		Difficulty:  big.NewInt(0x30000), // unused
 		GasLimit:    ctx.GasMeter().Limit(),
 		GasPrice:    ctx.MinGasPrices().AmountOf(emint.DenomDefault).Int,
 	}

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/params"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	emint "github.com/cosmos/ethermint/types"
@@ -68,8 +67,7 @@ func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk
 		GasPrice:    ctx.MinGasPrices().AmountOf(emint.DenomDefault).Int,
 	}
 
-	// TODO: Change defaulting to mainnet chainconfig
-	vmenv := vm.NewEVM(context, keeper.csdb.WithContext(ctx), params.MainnetChainConfig, vm.Config{})
+	vmenv := vm.NewEVM(context, keeper.csdb.WithContext(ctx), types.GenerateChainConfig(intChainID), vm.Config{})
 
 	var (
 		leftOverGas uint64

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -105,7 +105,10 @@ func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk
 	keeper.csdb.Finalise(true) // Change to depend on config
 
 	// TODO: Remove commit from tx handler (should be done at end of block)
-	keeper.csdb.Commit(true)
+	_, err = keeper.csdb.Commit(true)
+	if err != nil {
+		return sdk.ErrUnknownRequest("Failed to write data to kv store").Result()
+	}
 
 	// TODO: Consume gas from sender
 

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -2,8 +2,15 @@ package evm
 
 import (
 	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	emint "github.com/cosmos/ethermint/types"
 	"github.com/cosmos/ethermint/x/evm/types"
 )
 
@@ -22,20 +29,74 @@ func NewHandler(keeper Keeper) sdk.Handler {
 
 // Handle an Ethereum specific tx
 func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk.Result {
-	// TODO: Implement transaction logic
 	if err := msg.ValidateBasic(); err != nil {
 		return sdk.ErrUnknownRequest("Basic validation failed").Result()
 	}
 
-	// If no to address, create contract with evm.Create(...)
+	// parse the chainID from a string to a base-10 integer
+	intChainID, ok := new(big.Int).SetString(ctx.ChainID(), 10)
+	if !ok {
+		return emint.ErrInvalidChainID(fmt.Sprintf("invalid chainID: %s", ctx.ChainID())).Result()
+	}
 
-	// Else Call contract with evm.Call(...)
+	// TODO: move this logic into a .From() function added to EthereumTxMsg
+	chainIDMul := new(big.Int).Mul(intChainID, big.NewInt(2))
+	V := new(big.Int).Sub(msg.Data.V, chainIDMul)
+	V.Sub(V, big.NewInt(8))
+
+	sigHash := msg.RLPSignBytes(intChainID)
+	sender, err := types.RecoverEthSig(msg.Data.R, msg.Data.S, V, sigHash)
+	if err != nil {
+		// TODO: Change this error
+		return sdk.ErrUnknownAddress("Unknown Sender").Result()
+	}
+
+	// Create context for evm
+	context := vm.Context{
+		CanTransfer: core.CanTransfer, // Looks good, but double check
+		Transfer:    core.Transfer,    // Looks good, but double check
+		Origin:      sender,
+		Coinbase:    common.Address{},
+		BlockNumber: big.NewInt(ctx.BlockHeight()),
+		Time:        new(big.Int).SetUint64(5), // TODO: doesn't seem necessary
+		Difficulty:  big.NewInt(0x30000),       // TODO: doesn't seem used in call or create
+		GasLimit:    ctx.GasMeter().Limit(),
+		GasPrice:    ctx.MinGasPrices().AmountOf(emint.DenomDefault).Int,
+	}
+
+	vmenv := vm.NewEVM(context, keeper.csdb, params.MainnetChainConfig, vm.Config{})
+
+	contractCreation := msg.To() == nil
+	senderRef := vm.AccountRef(sender)
+	var (
+		gasUsed uint64
+		vmerr   error
+		ret     []byte
+	)
+
+	if contractCreation {
+		// TODO: Check if ctx.GasMeter().Limit() matches
+		ret, _, gasUsed, vmerr = vmenv.Create(senderRef, msg.Data.Payload, ctx.GasMeter().Limit(), msg.Data.Amount)
+	} else {
+		// Increment the nonce for the next transaction
+		keeper.csdb.SetNonce(sender, keeper.csdb.GetNonce(sender)+1)
+		ret, gasUsed, vmerr = vmenv.Call(senderRef, *msg.To(), msg.Data.Payload, ctx.GasMeter().Limit(), msg.Data.Amount)
+	}
 
 	// handle errors
+	if vmerr != nil {
+		// TODO: Change this error to custom vm error
+		return sdk.ErrUnknownRequest("VM execution error").Result()
+	}
 
-	// Refund remaining gas from tx (Will supply keeper need to be introduced to evm Keeper to do this)
+	// Refund remaining gas from tx (Check these values and ensure gas is being consumed correctly)
+	ctx.GasMeter().ConsumeGas(gasUsed, "VM execution")
 
 	// add balance for the processor of the tx (determine who rewards are being processed to)
+	// TODO: Double check nothing needs to be done here
+
+	// TODO: Remove this
+	fmt.Println("VM Return: ", ret)
 
 	return sdk.Result{}
 }

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -101,7 +101,7 @@ func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk
 		fmt.Println(addr)
 	} else {
 		// Increment the nonce for the next transaction
-		keeper.SetNonce(ctx, sender, keeper.GetNonce(ctx, sender)+1)
+		keeper.csdb.SetNonce(sender, keeper.csdb.GetNonce(sender)+1)
 		// fmt.Println("\tPRE BALANCE: ", keeper.GetBalance(ctx, *msg.To()))
 		// fmt.Println("\tSENDER BALANCE: ", keeper.GetBalance(ctx, sender))
 		// fmt.Println("\tSENDER: ", sender.Hex())

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -29,11 +29,6 @@ func NewHandler(keeper Keeper) sdk.Handler {
 
 // Handle an Ethereum specific tx
 func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk.Result {
-	// defer func() {
-	// 	if r := recover(); r != nil {
-	// 		fmt.Println("\tPanic recovered: ", r)
-	// 	}
-	// }()
 	if err := msg.ValidateBasic(); err != nil {
 		return err.Result()
 	}

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -80,10 +80,11 @@ func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk
 		GasPrice:    ctx.MinGasPrices().AmountOf(emint.DenomDefault).Int,
 	}
 
-	vmenv := vm.NewEVM(context, keeper.csdb, params.MainnetChainConfig, vm.Config{})
+	vmenv := vm.NewEVM(context, keeper.csdb.WithContext(ctx), params.MainnetChainConfig, vm.Config{})
 
 	var (
 		// leftOverGas uint64
+		addr      common.Address
 		vmerr     error
 		ret       []byte
 		senderRef = vm.AccountRef(sender)
@@ -96,7 +97,8 @@ func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk
 
 	if contractCreation {
 		// TODO: Check if ctx.GasMeter().Limit() matches
-		ret, _, _, vmerr = vmenv.Create(senderRef, msg.Data.Payload, msg.Data.GasLimit, msg.Data.Amount)
+		ret, addr, _, vmerr = vmenv.Create(senderRef, msg.Data.Payload, msg.Data.GasLimit, msg.Data.Amount)
+		fmt.Println(addr)
 	} else {
 		// Increment the nonce for the next transaction
 		keeper.SetNonce(ctx, sender, keeper.GetNonce(ctx, sender)+1)

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -94,7 +94,8 @@ func (am AppModule) NewQuerierHandler() sdk.Querier {
 
 func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
 
-func (am AppModule) EndBlock(sdk.Context, abci.RequestEndBlock) []abci.ValidatorUpdate {
+func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+	// TODO: Commit database here ?
 	return []abci.ValidatorUpdate{}
 }
 

--- a/x/evm/types/chain_config.go
+++ b/x/evm/types/chain_config.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// GenerateChainConfig returns an Ethereum chainconfig for EVM state transitions
+func GenerateChainConfig(chainID *big.Int) *params.ChainConfig {
+	// TODO: Update chainconfig to take in parameters for fork blocks
+	return &params.ChainConfig{
+		ChainID:             chainID,
+		HomesteadBlock:      big.NewInt(0),
+		DAOForkBlock:        big.NewInt(0),
+		DAOForkSupport:      true,
+		EIP150Block:         big.NewInt(0),
+		EIP150Hash:          common.HexToHash("0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+	}
+}

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -273,7 +273,7 @@ func (msg *EthereumTxMsg) VerifySig(chainID *big.Int) (ethcmn.Address, error) {
 	V.Sub(V, big8)
 
 	sigHash := msg.RLPSignBytes(chainID)
-	sender, err := recoverEthSig(msg.Data.R, msg.Data.S, V, sigHash)
+	sender, err := RecoverEthSig(msg.Data.R, msg.Data.S, V, sigHash)
 	if err != nil {
 		return ethcmn.Address{}, err
 	}
@@ -321,7 +321,7 @@ func TxDecoder(cdc *codec.Codec) sdk.TxDecoder {
 // returns the sender or an error.
 //
 // Ref: Ethereum Yellow Paper (BYZANTIUM VERSION 69351d5) Appendix F
-func recoverEthSig(R, S, Vb *big.Int, sigHash ethcmn.Hash) (ethcmn.Address, error) {
+func RecoverEthSig(R, S, Vb *big.Int, sigHash ethcmn.Hash) (ethcmn.Address, error) {
 	if Vb.BitLen() > 8 {
 		return ethcmn.Address{}, errors.New("invalid signature")
 	}

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -273,7 +273,7 @@ func (msg *EthereumTxMsg) VerifySig(chainID *big.Int) (ethcmn.Address, error) {
 	V.Sub(V, big8)
 
 	sigHash := msg.RLPSignBytes(chainID)
-	sender, err := RecoverEthSig(msg.Data.R, msg.Data.S, V, sigHash)
+	sender, err := recoverEthSig(msg.Data.R, msg.Data.S, V, sigHash)
 	if err != nil {
 		return ethcmn.Address{}, err
 	}
@@ -321,7 +321,7 @@ func TxDecoder(cdc *codec.Codec) sdk.TxDecoder {
 // returns the sender or an error.
 //
 // Ref: Ethereum Yellow Paper (BYZANTIUM VERSION 69351d5) Appendix F
-func RecoverEthSig(R, S, Vb *big.Int, sigHash ethcmn.Hash) (ethcmn.Address, error) {
+func recoverEthSig(R, S, Vb *big.Int, sigHash ethcmn.Hash) (ethcmn.Address, error) {
 	if Vb.BitLen() > 8 {
 		return ethcmn.Address{}, errors.New("invalid signature")
 	}

--- a/x/evm/types/state_object.go
+++ b/x/evm/types/state_object.go
@@ -80,7 +80,12 @@ type (
 func newObject(db *CommitStateDB, accProto auth.Account) *stateObject {
 	acc, ok := accProto.(*types.Account)
 	if !ok {
-		panic(fmt.Sprintf("invalid account type for state object: %T", acc))
+		// State object can be created from a baseAccount
+		baseAccount, ok := accProto.(*auth.BaseAccount)
+		if !ok {
+			panic(fmt.Sprintf("invalid account type for state object: %T", accProto))
+		}
+		acc = &types.Account{BaseAccount: baseAccount}
 	}
 
 	if acc.CodeHash == nil {


### PR DESCRIPTION
- Updates CLI command to have optional to address to allow for contract creation 
- Fixes account encoding and decoding from implicit static codec reference
- Updates Ethermint errors
- Implements state transition function/ Handler logic to process Ethereum msgs/txs

Will put up as a draft PR since gas isn't actually consumed from the account and validators are not rewarded, but we can merge it in and create an issue to update when the functionality is decided on if wanted. (Would be nice to get this in to be able to test RPC calls)

To run:
```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id 3
emintcli config chain-id 3
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli keys add austin
testpass
testpass
emintcli emintkeys add austineth
testpass
testpass
emintd add-genesis-account $(emintcli keys show austin -a) 1000photon,100000000stake
emintd add-genesis-account $(emintcli emintkeys show austineth -a) 100000000photon,100000000stake
emintd gentx --name austin
testpass
emintd collect-gentxs
emintd validate-genesis
emintd start --pruning=nothing --rpc.unsafe

```

To send a transaction:
```
emintcli tx ethermint generate-eth-tx 5photon 22011 6 test 756F45E3FA69347A9A973A725E3C98bC4db0b5a0 --from austineth
```

Contract creation:
```
emintcli tx ethermint generate-eth-tx 5photon 22011 6 test --from austineth
```