### PR TITLE
RPC unlock Ethermint key and eth_sign

### DIFF
--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -4,11 +4,12 @@ package rpc
 
 import (
 	"github.com/cosmos/cosmos-sdk/client/context"
+	emintcrypto "github.com/cosmos/ethermint/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // GetRPCAPIs returns the list of all APIs
-func GetRPCAPIs(cliCtx context.CLIContext) []rpc.API {
+func GetRPCAPIs(cliCtx context.CLIContext, key emintcrypto.PrivKeySecp256k1) []rpc.API {
 	return []rpc.API{
 		{
 			Namespace: "web3",
@@ -19,7 +20,7 @@ func GetRPCAPIs(cliCtx context.CLIContext) []rpc.API {
 		{
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   NewPublicEthAPI(cliCtx),
+			Service:   NewPublicEthAPI(cliCtx, key),
 			Public:    true,
 		},
 		{

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -14,11 +14,19 @@ func GetRPCAPIs(cliCtx context.CLIContext) []rpc.API {
 			Namespace: "web3",
 			Version:   "1.0",
 			Service:   NewPublicWeb3API(),
+			Public:    true,
 		},
 		{
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   NewPublicEthAPI(cliCtx),
+			Public:    true,
+		},
+		{
+			Namespace: "personal",
+			Version:   "1.0",
+			Service:   NewPersonalEthAPI(cliCtx),
+			Public:    false,
 		},
 	}
 }

--- a/rpc/config.go
+++ b/rpc/config.go
@@ -5,13 +5,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/spf13/cobra"
+
 	"log"
 )
 
-// defaultModules returns all available modules
-func defaultModules() []string {
-	return []string{"web3", "eth"}
-}
+const (
+	flagUnlockKey = "unlock-key"
+)
 
 // Config contains configuration fields that determine the behavior of the RPC HTTP server.
 // TODO: These may become irrelevant if HTTP config is handled by the SDK
@@ -30,7 +30,10 @@ type Config struct {
 
 // Web3RpcCmd creates a CLI command to start RPC server
 func Web3RpcCmd(cdc *codec.Codec) *cobra.Command {
-	return lcd.ServeCommand(cdc, registerRoutes)
+	cmd := lcd.ServeCommand(cdc, registerRoutes)
+	// Attach flag to cmd output to be handled in registerRoutes
+	cmd.Flags().String(flagUnlockKey, "", "Select a key to unlock on the RPC server")
+	return cmd
 }
 
 // registerRoutes creates a new server and registers the `/rpc` endpoint.
@@ -40,11 +43,7 @@ func registerRoutes(rs *lcd.RestServer) {
 	apis := GetRPCAPIs(rs.CliCtx)
 
 	// TODO: Allow cli to configure modules https://github.com/ChainSafe/ethermint/issues/74
-	modules := defaultModules()
 	whitelist := make(map[string]bool)
-	for _, module := range modules {
-		whitelist[module] = true
-	}
 
 	// Register all the APIs exposed by the services
 	for _, api := range apis {

--- a/rpc/config.go
+++ b/rpc/config.go
@@ -47,14 +47,17 @@ func registerRoutes(rs *lcd.RestServer) {
 	s := rpc.NewServer()
 	accountName := viper.GetString(flagUnlockKey)
 
-	passphrase, err := emintkeys.GetPassphrase(accountName)
-	if err != nil {
-		return
-	}
+	var emintKey emintcrypto.PrivKeySecp256k1
+	if len(accountName) > 0 {
+		passphrase, err := emintkeys.GetPassphrase(accountName)
+		if err != nil {
+			log.Println(err)
+		}
 
-	emintKey, err := unlockKeyFromNameAndPassphrase(accountName, passphrase)
-	if err != nil {
-		log.Println(err)
+		emintKey, err = unlockKeyFromNameAndPassphrase(accountName, passphrase)
+		if err != nil {
+			log.Println(err)
+		}
 	}
 
 	apis := GetRPCAPIs(rs.CliCtx, emintKey)
@@ -76,10 +79,6 @@ func registerRoutes(rs *lcd.RestServer) {
 }
 
 func unlockKeyFromNameAndPassphrase(accountName, passphrase string) (emintKey emintcrypto.PrivKeySecp256k1, err error) {
-	if len(accountName) == 0 {
-		return
-	}
-
 	keybase, err := emintkeys.NewKeyBaseFromHomeFlag()
 	if err != nil {
 		return

--- a/rpc/config.go
+++ b/rpc/config.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/cosmos/cosmos-sdk/client/lcd"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -51,12 +50,12 @@ func registerRoutes(rs *lcd.RestServer) {
 	if len(accountName) > 0 {
 		passphrase, err := emintkeys.GetPassphrase(accountName)
 		if err != nil {
-			log.Println(err)
+			panic(err)
 		}
 
 		emintKey, err = unlockKeyFromNameAndPassphrase(accountName, passphrase)
 		if err != nil {
-			log.Println(err)
+			panic(err)
 		}
 	}
 
@@ -69,8 +68,7 @@ func registerRoutes(rs *lcd.RestServer) {
 	for _, api := range apis {
 		if whitelist[api.Namespace] || (len(whitelist) == 0 && api.Public) {
 			if err := s.RegisterName(api.Namespace, api.Service); err != nil {
-				log.Println(err)
-				return
+				panic(err)
 			}
 		}
 	}

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -5,8 +5,10 @@ import (
 	"math/big"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
+	emintcrypto "github.com/cosmos/ethermint/crypto"
 	"github.com/cosmos/ethermint/version"
 	"github.com/cosmos/ethermint/x/evm/types"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -16,12 +18,14 @@ import (
 // PublicEthAPI is the eth_ prefixed set of APIs in the Web3 JSON-RPC spec.
 type PublicEthAPI struct {
 	cliCtx context.CLIContext
+	key    emintcrypto.PrivKeySecp256k1
 }
 
 // NewPublicEthAPI creates an instance of the public ETH Web3 API.
-func NewPublicEthAPI(cliCtx context.CLIContext) *PublicEthAPI {
+func NewPublicEthAPI(cliCtx context.CLIContext, key emintcrypto.PrivKeySecp256k1) *PublicEthAPI {
 	return &PublicEthAPI{
 		cliCtx: cliCtx,
+		key:    key,
 	}
 }
 

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -171,7 +171,13 @@ func (e *PublicEthAPI) Sign(address common.Address, data hexutil.Bytes) (hexutil
 		return nil, keystore.ErrLocked
 	}
 
-	return e.key.Sign(data)
+	// Sign the requested hash with the wallet
+	signature, err := e.key.Sign(data)
+	if err == nil {
+		signature[64] += 27 // Transform V from 0/1 to 27/28 according to the yellow paper
+	}
+
+	return signature, err
 }
 
 // SendTransaction sends an Ethereum transaction.

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -167,7 +167,7 @@ func (e *PublicEthAPI) GetCode(address common.Address, blockNumber rpc.BlockNumb
 // Sign signs the provided data using the private key of address via Geth's signature standard.
 func (e *PublicEthAPI) Sign(address common.Address, data hexutil.Bytes) (hexutil.Bytes, error) {
 	// TODO: Change this functionality to find an unlocked account by address
-	if e.key == nil || bytes.Compare(e.key.PubKey().Address().Bytes(), address.Bytes()) != 0 {
+	if e.key == nil || !bytes.Equal(e.key.PubKey().Address().Bytes(), address.Bytes()) {
 		return nil, keystore.ErrLocked
 	}
 

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/cosmos/ethermint/version"
 	"github.com/cosmos/ethermint/x/evm/types"
 
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -163,8 +165,13 @@ func (e *PublicEthAPI) GetCode(address common.Address, blockNumber rpc.BlockNumb
 }
 
 // Sign signs the provided data using the private key of address via Geth's signature standard.
-func (e *PublicEthAPI) Sign(address common.Address, data hexutil.Bytes) hexutil.Bytes {
-	return nil
+func (e *PublicEthAPI) Sign(address common.Address, data hexutil.Bytes) (hexutil.Bytes, error) {
+	// TODO: Change this functionality to find an unlocked account by address
+	if e.key == nil || bytes.Compare(e.key.PubKey().Address().Bytes(), address.Bytes()) != 0 {
+		return nil, keystore.ErrLocked
+	}
+
+	return e.key.Sign(data)
 }
 
 // SendTransaction sends an Ethereum transaction.

--- a/rpc/personal_api.go
+++ b/rpc/personal_api.go
@@ -1,0 +1,34 @@
+package rpc
+
+import (
+	"context"
+
+	sdkcontext "github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// PersonalEthAPI is the eth_ prefixed set of APIs in the Web3 JSON-RPC spec.
+type PersonalEthAPI struct {
+	cliCtx sdkcontext.CLIContext
+}
+
+// NewPersonalEthAPI creates an instance of the public ETH Web3 API.
+func NewPersonalEthAPI(cliCtx sdkcontext.CLIContext) *PersonalEthAPI {
+	return &PersonalEthAPI{
+		cliCtx: cliCtx,
+	}
+}
+
+// Sign calculates an Ethereum ECDSA signature for:
+// keccack256("\x19Ethereum Signed Message:\n" + len(message) + message))
+//
+// Note, the produced signature conforms to the secp256k1 curve R, S and V values,
+// where the V value will be 27 or 28 for legacy reasons.
+//
+// The key used to calculate the signature is decrypted with the given password.
+//
+// https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_sign\
+func (e *PersonalEthAPI) Sign(ctx context.Context, data hexutil.Bytes, addr common.Address, passwd string) (hexutil.Bytes, error) {
+	return nil, nil
+}

--- a/rpc/personal_api.go
+++ b/rpc/personal_api.go
@@ -28,7 +28,7 @@ func NewPersonalEthAPI(cliCtx sdkcontext.CLIContext) *PersonalEthAPI {
 //
 // The key used to calculate the signature is decrypted with the given password.
 //
-// https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_sign\
+// https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_sign
 func (e *PersonalEthAPI) Sign(ctx context.Context, data hexutil.Bytes, addr common.Address, passwd string) (hexutil.Bytes, error) {
 	return nil, nil
 }


### PR DESCRIPTION
- Implements #35 with key if enabled (eth_signTransaction is undocumented but may be useful to include signing a tx object)
- Attaches an unlocked key to the Public RPC API to be used for tx signing through rpc
- Sets up framework for personal_sign to sign data without an unlocked key on the server (is not enabled by default and would require #74 to enable)

To run:

```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id 3
emintcli config chain-id 3
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli emintkeys add austineth
testpass
testpass
emintcli rest-server --laddr "tcp://localhost:8545" --unlock-key austineth
testpass

```

```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sign","params":["0x<USE ETHEREUM OUTPUT KEY FROM emintkeys add austineth>", "0xdeadbeaf"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
## {"jsonrpc":"2.0","id":1,"result":"0xcd237050e74b9c2123312ef737715cc66e4f6cc30dd11497c98bafc486e5db56123b1b1d7eb7bbc5dc8c599e894170a138f922521131c0745326bbad8bd8d7e501"}
```