### PR TITLE
Implement eth_accounts

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
+	emintkeys "github.com/cosmos/ethermint/keys"
 	"github.com/cosmos/ethermint/version"
 	"github.com/cosmos/ethermint/x/evm/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -58,8 +59,24 @@ func (e *PublicEthAPI) GasPrice() *hexutil.Big {
 }
 
 // Accounts returns the list of accounts available to this node.
-func (e *PublicEthAPI) Accounts() []common.Address {
-	return nil
+func (e *PublicEthAPI) Accounts() ([]common.Address, error) {
+	addresses := make([]common.Address, 0) // return [] instead of nil if empty
+	keybase, err := emintkeys.NewKeyBaseFromHomeFlag()
+	if err != nil {
+		return addresses, err
+	}
+
+	infos, err := keybase.List()
+	if err != nil {
+		return addresses, err
+	}
+
+	for _, info := range infos {
+		addressBytes := info.GetPubKey().Address().Bytes()
+		addresses = append(addresses, common.BytesToAddress(addressBytes))
+	}
+
+	return addresses, nil
 }
 
 // BlockNumber returns the current block number.


### PR DESCRIPTION
- Implements #25 Using keys set up with Ethermint keybase

To run:

```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id 3
emintcli config chain-id 3
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli emintkeys add austineth
testpass
testpass
# Add any other keys here
emintcli rest-server --laddr "tcp://localhost:8545"

```

Test:

```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
# With Accounts: {"jsonrpc":"2.0","id":1,"result":["0x030332fd5114667ca29b9a73e005333d8fd013cb","0x3442b1b15c5987cd4ed1c08e2ba3dd40d3542b9f"]}
# Without accounts: {"jsonrpc":"2.0","id":1,"result":[]}
```