### PR TITLE
Implement eth_sendRawTransaction

### DIFF
--- a/rpc/config.go
+++ b/rpc/config.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/lcd"
 	"github.com/cosmos/cosmos-sdk/codec"
 	emintcrypto "github.com/cosmos/ethermint/crypto"
@@ -35,8 +36,8 @@ type Config struct {
 // Web3RpcCmd creates a CLI command to start RPC server
 func Web3RpcCmd(cdc *codec.Codec) *cobra.Command {
 	cmd := lcd.ServeCommand(cdc, registerRoutes)
-	// Attach flag to cmd output to be handled in registerRoutes
 	cmd.Flags().String(flagUnlockKey, "", "Select a key to unlock on the RPC server")
+	cmd.Flags().StringP(flags.FlagBroadcastMode, "b", flags.BroadcastSync, "Transaction broadcasting mode (sync|async|block)")
 	return cmd
 }
 

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -223,7 +223,9 @@ func (e *PublicEthAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, erro
 
 	// TODO: Possibly log the contract creation address (if recipient address is nil) or tx data
 	// TODO: Determine why tx is not being broadcasted to node
-	res, err := e.cliCtx.BroadcastTxSync(txBytes)
+	res, err := e.cliCtx.BroadcastTx(txBytes)
+	// If error is encountered on the node, the broadcast will not return an error
+	fmt.Println(res.RawLog)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -209,20 +209,20 @@ func (e *PublicEthAPI) SendTransaction(args core.SendTxArgs) common.Hash {
 func (e *PublicEthAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, error) {
 	tx := new(types.EthereumTxMsg)
 
+	// RLP decode raw transaction bytes
 	if err := rlp.DecodeBytes(data, tx); err != nil {
 		// Return nil is for when gasLimit overflows uint64
-		return common.Hash{}, err
+		return common.Hash{}, nil
 	}
 
+	// Encode transaction by default Tx encoder
 	txEncoder := authutils.GetTxEncoder(e.cliCtx.Codec)
-
 	txBytes, err := txEncoder(tx)
 	if err != nil {
 		return common.Hash{}, err
 	}
 
 	// TODO: Possibly log the contract creation address (if recipient address is nil) or tx data
-	// TODO: Determine why tx is not being broadcasted to node
 	res, err := e.cliCtx.BroadcastTx(txBytes)
 	// If error is encountered on the node, the broadcast will not return an error
 	fmt.Println(res.RawLog)

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -131,7 +131,8 @@ func (msg EthereumTxMsg) ValidateBasic() sdk.Error {
 		return types.ErrInvalidValue(fmt.Sprintf("Price must be positive: %x", msg.Data.Price))
 	}
 
-	if msg.Data.Amount.Sign() != 1 {
+	// Amount can be 0
+	if msg.Data.Amount.Sign() == -1 {
 		return types.ErrInvalidValue(fmt.Sprintf("amount must be positive: %x", msg.Data.Amount))
 	}
 


### PR DESCRIPTION
- RLP decodes raw transaction bytes, encodes it based on TxEncoder (amino in this case), then broadcasts tx to the node

I verified the tx decoding based on how I encoded the transaction and everything is functional as intended for this endpoint. One thing that needs to be revisited and verified is the transaction signing and verifying based on config/fork as there is no rigid setup for config for the running node.

To run:
```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id 3
emintcli config chain-id 3
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli keys add austin
testpass
testpass
emintcli emintkeys add austineth
testpass
testpass
emintd add-genesis-account $(emintcli keys show austin -a) 1000photon,100000000stake
emintd add-genesis-account $(emintcli emintkeys show austineth -a) 100000000photon,100000000stake
emintd gentx --name austin
testpass
emintd collect-gentxs
emintd validate-genesis
emintd start --pruning=nothing --rpc.unsafe

```

request:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0xf866068609184e72a0008303000094fa3caabc8eefec2b5e2895e5afbf79379e7268a780801ca07f158e380711daf356974ea62bd7850e58e9b970bd1f1bd284a1bd1f38356cc6a05491535e9f67184a37e7f4209affc580df8fda69f1bfa67d6d5c134d57a52951"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
## {"jsonrpc":"2.0","id":1,"result":"0xd3137915bb6c655e6097e84326e17f6742b2f97796f4a595653ea277f4314bbf"}
```

Transaction probably won't work because it is signed with wrong chainconfig, but can test with another raw transaction if needed.