### PR TITLE
Implement eth_sendTransaction

### DIFF
--- a/keys/show.go
+++ b/keys/show.go
@@ -74,7 +74,7 @@ func runShowCmd(cmd *cobra.Command, args []string) (err error) {
 	isShowEitherAddr := isShowAddr || isShowEthAddr
 
 	if isShowEitherAddr && isShowPubKey {
-		return errors.New("cannot use both --address and --pubkey at once")
+		return errors.New("cannot get address, with --address or --ethwallet, and --pubkey at once")
 	}
 
 	if isOutputSet && (isShowEitherAddr || isShowPubKey) {

--- a/keys/show.go
+++ b/keys/show.go
@@ -19,6 +19,8 @@ import (
 const (
 	// FlagAddress is the flag for the user's address on the command line.
 	FlagAddress = "address"
+	// FlagAddress is the flag for the user's address on the command line.
+	FlagETHAddress = "ethwallet"
 	// FlagPublicKey represents the user's public key on the command line.
 	FlagPublicKey = "pubkey"
 	// FlagBechPrefix defines a desired Bech32 prefix encoding for a key.
@@ -38,6 +40,7 @@ func showKeysCmd() *cobra.Command {
 
 	cmd.Flags().String(FlagBechPrefix, sdk.PrefixAccount, "The Bech32 prefix encoding for a key (acc|val|cons)")
 	cmd.Flags().BoolP(FlagAddress, "a", false, "Output the address only (overrides --output)")
+	cmd.Flags().BoolP(FlagETHAddress, "w", false, "Output the Ethereum address only (overrides --output)")
 	cmd.Flags().BoolP(FlagPublicKey, "p", false, "Output the public key only (overrides --output)")
 	cmd.Flags().BoolP(FlagDevice, "d", false, "Output the address in a ledger device")
 	cmd.Flags().Bool(flags.FlagIndentResponse, false, "Add indent to JSON response")
@@ -58,6 +61,7 @@ func runShowCmd(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	isShowAddr := viper.GetBool(FlagAddress)
+	isShowEthAddr := viper.GetBool(FlagETHAddress)
 	isShowPubKey := viper.GetBool(FlagPublicKey)
 	isShowDevice := viper.GetBool(FlagDevice)
 
@@ -67,11 +71,13 @@ func runShowCmd(cmd *cobra.Command, args []string) (err error) {
 		isOutputSet = tmp.Changed
 	}
 
-	if isShowAddr && isShowPubKey {
+	isShowEitherAddr := isShowAddr || isShowEthAddr
+
+	if isShowEitherAddr && isShowPubKey {
 		return errors.New("cannot use both --address and --pubkey at once")
 	}
 
-	if isOutputSet && (isShowAddr || isShowPubKey) {
+	if isOutputSet && (isShowEitherAddr || isShowPubKey) {
 		return errors.New("cannot use --output with --address or --pubkey")
 	}
 
@@ -80,6 +86,8 @@ func runShowCmd(cmd *cobra.Command, args []string) (err error) {
 	switch {
 	case isShowAddr:
 		printKeyAddress(info, keyOutputFunction)
+	case isShowEthAddr:
+		printKeyEthAddress(info, keyOutputFunction)
 	case isShowPubKey:
 		printPubKey(info, keyOutputFunction)
 	default:

--- a/keys/utils.go
+++ b/keys/utils.go
@@ -148,6 +148,15 @@ func printKeyAddress(info cosmosKeys.Info, bechKeyOut bechKeyOutFn) {
 	fmt.Println(ko.Address)
 }
 
+func printKeyEthAddress(info cosmosKeys.Info, bechKeyOut bechKeyOutFn) {
+	ko, err := bechKeyOut(info)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(ko.ETHAddress)
+}
+
 func printPubKey(info cosmosKeys.Info, bechKeyOut bechKeyOutFn) {
 	ko, err := bechKeyOut(info)
 	if err != nil {

--- a/rpc/addrlock.go
+++ b/rpc/addrlock.go
@@ -1,0 +1,38 @@
+package rpc
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// AddrLocker is a mutex structure used to avoid querying outdated account data
+type AddrLocker struct {
+	mu    sync.Mutex
+	locks map[common.Address]*sync.Mutex
+}
+
+// lock returns the lock of the given address.
+func (l *AddrLocker) lock(address common.Address) *sync.Mutex {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.locks == nil {
+		l.locks = make(map[common.Address]*sync.Mutex)
+	}
+	if _, ok := l.locks[address]; !ok {
+		l.locks[address] = new(sync.Mutex)
+	}
+	return l.locks[address]
+}
+
+// LockAddr locks an account's mutex. This is used to prevent another tx getting the
+// same nonce until the lock is released. The mutex prevents the (an identical nonce) from
+// being read again during the time that the first transaction is being signed.
+func (l *AddrLocker) LockAddr(address common.Address) {
+	l.lock(address).Lock()
+}
+
+// UnlockAddr unlocks the mutex of the given account.
+func (l *AddrLocker) UnlockAddr(address common.Address) {
+	l.lock(address).Unlock()
+}

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -10,6 +10,7 @@ import (
 
 // GetRPCAPIs returns the list of all APIs
 func GetRPCAPIs(cliCtx context.CLIContext, key emintcrypto.PrivKeySecp256k1) []rpc.API {
+	nonceLock := new(AddrLocker)
 	return []rpc.API{
 		{
 			Namespace: "web3",
@@ -20,13 +21,13 @@ func GetRPCAPIs(cliCtx context.CLIContext, key emintcrypto.PrivKeySecp256k1) []r
 		{
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   NewPublicEthAPI(cliCtx, key),
+			Service:   NewPublicEthAPI(cliCtx, nonceLock, key),
 			Public:    true,
 		},
 		{
 			Namespace: "personal",
 			Version:   "1.0",
-			Service:   NewPersonalEthAPI(cliCtx),
+			Service:   NewPersonalEthAPI(cliCtx, nonceLock),
 			Public:    false,
 		},
 	}

--- a/rpc/args/send_tx.go
+++ b/rpc/args/send_tx.go
@@ -1,0 +1,22 @@
+package args
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// SendTxArgs represents the arguments to sumbit a new transaction into the transaction pool.
+// Duplicate struct definition since geth struct is in internal package
+// Ref: https://github.com/ethereum/go-ethereum/blob/release/1.9/internal/ethapi/api.go#L1346
+type SendTxArgs struct {
+	From     common.Address  `json:"from"`
+	To       *common.Address `json:"to"`
+	Gas      *hexutil.Uint64 `json:"gas"`
+	GasPrice *hexutil.Big    `json:"gasPrice"`
+	Value    *hexutil.Big    `json:"value"`
+	Nonce    *hexutil.Uint64 `json:"nonce"`
+	// We accept "data" and "input" for backwards-compatibility reasons. "input" is the
+	// newer name and should be preferred by clients.
+	Data  *hexutil.Bytes `json:"data"`
+	Input *hexutil.Bytes `json:"input"`
+}

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -9,6 +9,7 @@ import (
 	authutils "github.com/cosmos/cosmos-sdk/x/auth/client/utils"
 	emintcrypto "github.com/cosmos/ethermint/crypto"
 	emintkeys "github.com/cosmos/ethermint/keys"
+	"github.com/cosmos/ethermint/rpc/args"
 	"github.com/cosmos/ethermint/version"
 	"github.com/cosmos/ethermint/x/evm/types"
 
@@ -17,20 +18,23 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/ethereum/go-ethereum/signer/core"
 )
 
 // PublicEthAPI is the eth_ prefixed set of APIs in the Web3 JSON-RPC spec.
 type PublicEthAPI struct {
-	cliCtx context.CLIContext
-	key    emintcrypto.PrivKeySecp256k1
+	cliCtx    context.CLIContext
+	key       emintcrypto.PrivKeySecp256k1
+	nonceLock *AddrLocker
 }
 
 // NewPublicEthAPI creates an instance of the public ETH Web3 API.
-func NewPublicEthAPI(cliCtx context.CLIContext, key emintcrypto.PrivKeySecp256k1) *PublicEthAPI {
+func NewPublicEthAPI(cliCtx context.CLIContext, nonceLock *AddrLocker,
+	key emintcrypto.PrivKeySecp256k1) *PublicEthAPI {
+
 	return &PublicEthAPI{
-		cliCtx: cliCtx,
-		key:    key,
+		cliCtx:    cliCtx,
+		key:       key,
+		nonceLock: nonceLock,
 	}
 }
 
@@ -200,9 +204,49 @@ func (e *PublicEthAPI) Sign(address common.Address, data hexutil.Bytes) (hexutil
 }
 
 // SendTransaction sends an Ethereum transaction.
-func (e *PublicEthAPI) SendTransaction(args core.SendTxArgs) common.Hash {
-	var h common.Hash
-	return h
+func (e *PublicEthAPI) SendTransaction(args args.SendTxArgs) (common.Hash, error) {
+	// TODO: Change this functionality to find an unlocked account by address
+	if e.key == nil || !bytes.Equal(e.key.PubKey().Address().Bytes(), args.From.Bytes()) {
+		return common.Hash{}, keystore.ErrLocked
+	}
+
+	// Mutex lock the address' nonce to avoid assigning it to multiple requests
+	if args.Nonce == nil {
+		e.nonceLock.LockAddr(args.From)
+		defer e.nonceLock.UnlockAddr(args.From)
+	}
+
+	// Transaction defaults and terminate on failure
+	tx := new(types.EthereumTxMsg)
+
+	// Assemble transaction from fields
+	tx.PopulateFromArgs(args)
+
+	// // parse the chainID from a string to a base-10 integer
+	// intChainID, ok := new(big.Int).SetString(e.cliCtx.ChainID(), 10)
+	// if !ok {
+	// 	return common.Hash{}, fmt.Errorf("Invalid chainID")
+	// }
+
+	// // Sign transaction
+	// tx.Sign(intChainID, e.key.ToECDSA())
+
+	// Encode transaction by default Tx encoder
+	txEncoder := authutils.GetTxEncoder(e.cliCtx.Codec)
+	txBytes, err := txEncoder(tx)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	// Broadcast transaction
+	res, err := e.cliCtx.BroadcastTx(txBytes)
+	// If error is encountered on the node, the broadcast will not return an error
+	fmt.Println(res.RawLog)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return common.HexToHash(res.TxHash), nil
 }
 
 // SendRawTransaction send a raw Ethereum transaction.

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -18,6 +18,9 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/viper"
 )
 
 // PublicEthAPI is the eth_ prefixed set of APIs in the Web3 JSON-RPC spec.
@@ -222,14 +225,17 @@ func (e *PublicEthAPI) SendTransaction(args args.SendTxArgs) (common.Hash, error
 	// Assemble transaction from fields
 	tx.PopulateFromArgs(args)
 
-	// // parse the chainID from a string to a base-10 integer
-	// intChainID, ok := new(big.Int).SetString(e.cliCtx.ChainID(), 10)
-	// if !ok {
-	// 	return common.Hash{}, fmt.Errorf("Invalid chainID")
-	// }
+	// ChainID must be set as flag to send transaction
+	chainID := viper.GetString(flags.FlagChainID)
+	// parse the chainID from a string to a base-10 integer
+	intChainID, ok := new(big.Int).SetString(chainID, 10)
+	if !ok {
+		return common.Hash{}, fmt.Errorf(
+			fmt.Sprintf("Invalid chainID: %s, must be integer format", chainID))
+	}
 
-	// // Sign transaction
-	// tx.Sign(intChainID, e.key.ToECDSA())
+	// Sign transaction
+	tx.Sign(intChainID, e.key.ToECDSA())
 
 	// Encode transaction by default Tx encoder
 	txEncoder := authutils.GetTxEncoder(e.cliCtx.Codec)

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -219,11 +219,11 @@ func (e *PublicEthAPI) SendTransaction(args args.SendTxArgs) (common.Hash, error
 		defer e.nonceLock.UnlockAddr(args.From)
 	}
 
-	// Transaction defaults and terminate on failure
-	tx := new(types.EthereumTxMsg)
-
 	// Assemble transaction from fields
-	tx.PopulateFromArgs(args)
+	tx, err := types.GenerateFromArgs(args, e.cliCtx)
+	if err != nil {
+		return common.Hash{}, err
+	}
 
 	// ChainID must be set as flag to send transaction
 	chainID := viper.GetString(flags.FlagChainID)

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -247,12 +247,14 @@ func (e *PublicEthAPI) SendTransaction(args args.SendTxArgs) (common.Hash, error
 	// Broadcast transaction
 	res, err := e.cliCtx.BroadcastTx(txBytes)
 	// If error is encountered on the node, the broadcast will not return an error
+	// TODO: Remove res log
 	fmt.Println(res.RawLog)
 	if err != nil {
 		return common.Hash{}, err
 	}
 
-	return common.HexToHash(res.TxHash), nil
+	// Return RLP encoded bytes
+	return tx.Hash(), nil
 }
 
 // SendRawTransaction send a raw Ethereum transaction.
@@ -275,12 +277,14 @@ func (e *PublicEthAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, erro
 	// TODO: Possibly log the contract creation address (if recipient address is nil) or tx data
 	res, err := e.cliCtx.BroadcastTx(txBytes)
 	// If error is encountered on the node, the broadcast will not return an error
+	// TODO: Remove res log
 	fmt.Println(res.RawLog)
 	if err != nil {
 		return common.Hash{}, err
 	}
 
-	return common.HexToHash(res.TxHash), nil
+	// Return RLP encoded bytes
+	return tx.Hash(), nil
 }
 
 // CallArgs represents arguments to a smart contract call as provided by RPC clients.

--- a/rpc/personal_api.go
+++ b/rpc/personal_api.go
@@ -10,13 +10,15 @@ import (
 
 // PersonalEthAPI is the eth_ prefixed set of APIs in the Web3 JSON-RPC spec.
 type PersonalEthAPI struct {
-	cliCtx sdkcontext.CLIContext
+	cliCtx    sdkcontext.CLIContext
+	nonceLock *AddrLocker
 }
 
 // NewPersonalEthAPI creates an instance of the public ETH Web3 API.
-func NewPersonalEthAPI(cliCtx sdkcontext.CLIContext) *PersonalEthAPI {
+func NewPersonalEthAPI(cliCtx sdkcontext.CLIContext, nonceLock *AddrLocker) *PersonalEthAPI {
 	return &PersonalEthAPI{
-		cliCtx: cliCtx,
+		cliCtx:    cliCtx,
+		nonceLock: nonceLock,
 	}
 }
 

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/ethermint/types"
+	"github.com/cosmos/ethermint/rpc/args"
 
 	ethcmn "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -354,4 +355,9 @@ func recoverEthSig(R, S, Vb *big.Int, sigHash ethcmn.Hash) (ethcmn.Address, erro
 	copy(addr[:], ethcrypto.Keccak256(pub[1:])[12:])
 
 	return addr, nil
+}
+
+// PopulateFromArgs populates tx message with args (used in RPC API)
+func (msg *EthereumTxMsg) PopulateFromArgs(args args.SendTxArgs) {
+	// TODO
 }

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
@@ -10,9 +11,11 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/ethermint/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/ethermint/rpc/args"
+	"github.com/cosmos/ethermint/types"
 
+	"github.com/cosmos/cosmos-sdk/client/context"
 	ethcmn "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
@@ -358,6 +361,58 @@ func recoverEthSig(R, S, Vb *big.Int, sigHash ethcmn.Hash) (ethcmn.Address, erro
 }
 
 // PopulateFromArgs populates tx message with args (used in RPC API)
-func (msg *EthereumTxMsg) PopulateFromArgs(args args.SendTxArgs) {
-	// TODO
+func GenerateFromArgs(args args.SendTxArgs, ctx context.CLIContext) (msg *EthereumTxMsg, err error) {
+	var nonce uint64
+
+	var gasLimit uint64
+
+	amount := (*big.Int)(args.Value)
+
+	gasPrice := (*big.Int)(args.GasPrice)
+
+	if args.GasPrice == nil {
+		// Set default gas price
+		// TODO: Change to min gas price from context once available through server/daemon
+		gasPrice = big.NewInt(20)
+	}
+
+	if args.Nonce == nil {
+		// Get nonce (sequence) from account
+		from := sdk.AccAddress(args.From.Bytes())
+		_, nonce, err = authtypes.NewAccountRetriever(ctx).GetAccountNumberSequence(from)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		nonce = (uint64)(*args.Nonce)
+	}
+
+	if args.Data != nil && args.Input != nil && !bytes.Equal(*args.Data, *args.Input) {
+		return nil, fmt.Errorf(`both "data" and "input" are set and not equal. Please use "input" to pass transaction call data`)
+	}
+
+	// Sets input to either Input or Data, if both are set and not equal error above returns
+	var input []byte
+	if args.Input != nil {
+		input = *args.Input
+	} else {
+		input = *args.Data
+	}
+
+	if args.To == nil {
+		// Contract creation
+		if len(input) == 0 {
+			return nil, fmt.Errorf("contract creation without any data provided")
+		}
+	}
+
+	if args.Gas == nil {
+		// Estimate the gas usage if necessary.
+		// TODO: Set gas based on estimate when simulating txs are setup
+		gasLimit = 22000
+	} else {
+		gasLimit = (uint64)(*args.Gas)
+	}
+
+	return newEthereumTxMsg(nonce, args.To, amount, gasLimit, gasPrice, input), nil
 }

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -395,7 +395,7 @@ func GenerateFromArgs(args args.SendTxArgs, ctx context.CLIContext) (msg *Ethere
 	var input []byte
 	if args.Input != nil {
 		input = *args.Input
-	} else {
+	} else if args.Data != nil {
 		input = *args.Data
 	}
 


### PR DESCRIPTION
- Implements #36 eth_sendTransaction
- Added flag to output ETH address to be used more easily with RPC requests and CLI queries
- Added account mutex lock to RPC API context to avoid duplicate data returns (in the case of this PR, nonce values)

The rpc call works such that if any value is not provided in args, the value will be defaulted. The only ones that are defaulted statically currently are gas price (blocked by same issue as #24) and gas limit (blocked also by not having gas price and will do after tx simulating in #38). 

to run node:
```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id 3
emintcli config chain-id 3
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli keys add austin
testpass
testpass
emintcli emintkeys add austineth
testpass
testpass
emintd add-genesis-account $(emintcli keys show austin -a) 1000photon,100000000stake
emintd add-genesis-account $(emintcli emintkeys show austineth -a) 100000000photon,100000000stake
emintd gentx --name austin
testpass
emintd collect-gentxs
emintd validate-genesis
emintd start --pruning=nothing --rpc.unsafe

```

start server and unlock key for from address of transaction:
```
emintcli rest-server --laddr "tcp://localhost:8545" --unlock-key austineth
```

Send request with all parameters:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from":"0x'$(echo -n $(emintcli emintkeys show austineth -w))'","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","gas":"0x76c0","gasPrice":"0x12","value":"0x20","data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
## {"jsonrpc":"2.0","id":1,"result":"0x224948f3a29a8a6e555d93611ddbd28b524ef09c6461dbef506220dcfbaee7d0"}
```

Or with only from and to and let values be defaulted:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from":"0x'$(echo -n $(emintcli emintkeys show austineth -w))'","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567"}],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
## {"jsonrpc":"2.0","id":1,"result":"0x85017e8159a89117c5bfb951808c2a7df55416e381353ea263297d74d3260881"}
```

Edit: Oh and a contract creation for good measure:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from":"0x'$(echo -n $(emintcli emintkeys show austineth -w))'","data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675","gas":"0x76c0"}],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
## {"jsonrpc":"2.0","id":1,"result":"0x6783f8c8b76e9aa1e2ee940df3bc3dc062e43e6691d2c8aaabb361edec1a53bb"}
```