### PR TITLE
Fix transaction hash return

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -254,8 +254,8 @@ func (e *PublicEthAPI) SendTransaction(args args.SendTxArgs) (common.Hash, error
 		return common.Hash{}, err
 	}
 
-	// Return RLP encoded bytes
-	return tx.Hash(), nil
+	// Return transaction hash
+	return common.HexToHash(res.TxHash), nil
 }
 
 // SendRawTransaction send a raw Ethereum transaction.
@@ -284,8 +284,8 @@ func (e *PublicEthAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, erro
 		return common.Hash{}, err
 	}
 
-	// Return RLP encoded bytes
-	return tx.Hash(), nil
+	// Return transaction hash
+	return common.HexToHash(res.TxHash), nil
 }
 
 // CallArgs represents arguments to a smart contract call as provided by RPC clients.


### PR DESCRIPTION
- Fixes tx hash to return from eth_sendTransaction and eth_sendRawTransaction

Assumed the rlp hash would be returned for compatibility, but is unnecessary and hash of amino encoded tx needed for #42. Confirmed returned bytes equals the transaction hash processed on the daemon.