### PR TITLE
Implement eth_getTransactionByBlockNumberAndIndex

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -494,12 +494,9 @@ func (e *PublicEthAPI) GetTransactionByBlockNumberAndIndex(blockNum BlockNumber,
 	if uint64(idx) >= uint64(len(txs)) {
 		return nil, nil
 	}
-	txBytes := txs[idx]
-	var tx sdk.Tx
-	err = e.cliCtx.Codec.UnmarshalBinaryLengthPrefixed(txBytes, &tx)
-	ethTx, ok := tx.(*types.EthereumTxMsg)
-	if !ok || err != nil {
-		return nil, fmt.Errorf("Invalid transaction type, must be an amino encoded Ethereum transaction")
+	ethTx, err := bytesToEthTx(e.cliCtx, txs[idx])
+	if err != nil {
+		return nil, err
 	}
 
 	transaction := newRPCTransaction(ethTx, common.BytesToHash(header.ConsensusHash.Bytes()), uint64(header.Height), uint64(idx))

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -450,8 +450,28 @@ func (e *PublicEthAPI) GetTransactionByBlockHashAndIndex(hash common.Hash, idx h
 }
 
 // GetTransactionByBlockNumberAndIndex returns the transaction identified by number and index.
-func (e *PublicEthAPI) GetTransactionByBlockNumberAndIndex(blockNumber rpc.BlockNumber, idx hexutil.Uint) *Transaction {
-	return nil
+func (e *PublicEthAPI) GetTransactionByBlockNumberAndIndex(blockNum rpc.BlockNumber, idx hexutil.Uint) (*Transaction, error) {
+	value := blockNum.Int64()
+	block, err := e.cliCtx.Client.Block(&value)
+	if err != nil {
+		return nil, err
+	}
+	header := block.BlockMeta.Header
+
+	txs := block.Block.Txs
+	if uint64(idx) >= uint64(len(txs)) {
+		return nil, nil
+	}
+	txBytes := txs[idx]
+	var tx sdk.Tx
+	err = e.cliCtx.Codec.UnmarshalBinaryLengthPrefixed(txBytes, &tx)
+	ethTx, ok := tx.(*types.EthereumTxMsg)
+	if !ok || err != nil {
+		return nil, fmt.Errorf("Invalid transaction type, must be an amino encoded Ethereum transaction")
+	}
+
+	transaction := newRPCTransaction(ethTx, common.BytesToHash(header.ConsensusHash.Bytes()), uint64(header.Height), uint64(idx))
+	return transaction, nil
 }
 
 // GetTransactionReceipt returns the transaction receipt identified by hash.


### PR DESCRIPTION
- Implements #44 transaction by block number and index

Similar logic to the full tx decoding done in #87 

To test:
1. Run the Ethermint node:
```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id 3
emintcli config chain-id 3
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli keys add austin
testpass
testpass
emintcli emintkeys add austineth
testpass
testpass
emintd add-genesis-account $(emintcli keys show austin -a) 1000photon,100000000stake
emintd add-genesis-account $(emintcli emintkeys show austineth -a) 100000000photon,100000000stake
emintd gentx --name austin
testpass
emintd collect-gentxs
emintd validate-genesis
emintd start --pruning=nothing --rpc.unsafe --log_level "main:info,state:info,mempool:info,*:error"

```

2. Start rest server with unlocked key to send tx to test functionality
```
emintcli rest-server --laddr "tcp://localhost:8545" --unlock-key austineth
```

3. Send a transaction to test all values in a block:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from":"0x'$(echo -n $(emintcli emintkeys show austineth -w))'","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","gas":"0x76c0","gasPrice":"0x12","value":"0x20","data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
```

Retrieve transaction by block number and index (replace 0x2 and 0x0):
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByBlockNumberAndIndex","params":["0x2", "0x0"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
{"jsonrpc":"2.0","id":1,"result":{"blockHash":"0x048091bc7ddc283f77bfbf91d73c44da58c3df8a9cbc867405d8b7f3daada22f","blockNumber":"0x2","from":"0xd06b1d4c999dd69f9e6334baf047e398528bd4a7","gas":"0x76c0","gasPrice":"0x12","hash":"0x1b25646fcda0f30aa352e3d2825d0f5eef6e87d03f34253596b1197b1a7be050","input":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675","nonce":"0x0","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","transactionIndex":"0x0","value":"0x20","v":"0x2a","r":"0xc34947a181c44a0bf26817682025280f6673ced03af59604ece3a671435b2209","s":"0x3bb128d85d883136b2195fd224581e363105870eb14d1d894487c7a69691357e"}}
```
and you can check invalid indexes to see it returns null