### PR TITLE
Implements eth_getTransactionByHash

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -463,6 +463,10 @@ func (e *PublicEthAPI) GetTransactionByHash(hash common.Hash) (*Transaction, err
 	blockHash := common.BytesToHash(block.BlockMeta.Header.ConsensusHash)
 
 	ethTx, err := bytesToEthTx(e.cliCtx, tx.Tx)
+	if err != nil {
+		return nil, err
+	}
+
 	return newRPCTransaction(ethTx, blockHash, uint64(tx.Height), uint64(tx.Index)), nil
 }
 

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -451,7 +451,8 @@ func newRPCTransaction(tx *types.EthereumTxMsg, blockHash common.Hash, blockNumb
 func (e *PublicEthAPI) GetTransactionByHash(hash common.Hash) (*Transaction, error) {
 	tx, err := e.cliCtx.Client.Tx(hash.Bytes(), false)
 	if err != nil {
-		return nil, err
+		// Return nil for transaction when not found
+		return nil, nil
 	}
 
 	// Can either cache or just leave this out if not necessary

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -381,10 +381,8 @@ func convertTransactionsToRPC(cliCtx context.CLIContext, txs []tmtypes.Tx, block
 	transactions := make([]interface{}, len(txs))
 	gasUsed := big.NewInt(0)
 	for i, tx := range txs {
-		var stdTx sdk.Tx
-		err := cliCtx.Codec.UnmarshalBinaryLengthPrefixed(tx, &stdTx)
-		ethTx, ok := stdTx.(*types.EthereumTxMsg)
-		if !ok || err != nil {
+		ethTx, err := bytesToEthTx(cliCtx, tx)
+		if err != nil {
 			continue
 		}
 		// TODO: Remove gas usage calculation if saving gasUsed per block
@@ -410,6 +408,16 @@ type Transaction struct {
 	V                *hexutil.Big    `json:"v"`
 	R                *hexutil.Big    `json:"r"`
 	S                *hexutil.Big    `json:"s"`
+}
+
+func bytesToEthTx(cliCtx context.CLIContext, bz []byte) (*types.EthereumTxMsg, error) {
+	var stdTx sdk.Tx
+	err := cliCtx.Codec.UnmarshalBinaryLengthPrefixed(bz, &stdTx)
+	ethTx, ok := stdTx.(*types.EthereumTxMsg)
+	if !ok || err != nil {
+		return nil, fmt.Errorf("Invalid transaction type, must be an amino encoded Ethereum transaction")
+	}
+	return ethTx, nil
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
@@ -440,8 +448,21 @@ func newRPCTransaction(tx *types.EthereumTxMsg, blockHash common.Hash, blockNumb
 }
 
 // GetTransactionByHash returns the transaction identified by hash.
-func (e *PublicEthAPI) GetTransactionByHash(hash common.Hash) *Transaction {
-	return nil
+func (e *PublicEthAPI) GetTransactionByHash(hash common.Hash) (*Transaction, error) {
+	tx, err := e.cliCtx.Client.Tx(hash.Bytes(), false)
+	if err != nil {
+		return nil, err
+	}
+
+	// Can either cache or just leave this out if not necessary
+	block, err := e.cliCtx.Client.Block(&tx.Height)
+	if err != nil {
+		return nil, err
+	}
+	blockHash := common.BytesToHash(block.BlockMeta.Header.ConsensusHash)
+
+	ethTx, err := bytesToEthTx(e.cliCtx, tx.Tx)
+	return newRPCTransaction(ethTx, blockHash, uint64(tx.Height), uint64(tx.Index)), nil
 }
 
 // GetTransactionByBlockHashAndIndex returns the transaction identified by hash and index.


### PR DESCRIPTION
- Implements #42 eth_getTransactionByHash
- Adds function for amino encoded bytes to ethereum tx for consistency

nil on invalid hash and transaction data on valid hash

To test:
1. Run the Ethermint node:
```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id 3
emintcli config chain-id 3
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli keys add austin
testpass
testpass
emintcli emintkeys add austineth
testpass
testpass
emintd add-genesis-account $(emintcli keys show austin -a) 1000photon,100000000stake
emintd add-genesis-account $(emintcli emintkeys show austineth -a) 100000000photon,100000000stake
emintd gentx --name austin
testpass
emintd collect-gentxs
emintd validate-genesis
emintd start --pruning=nothing --rpc.unsafe --log_level "main:info,state:info,mempool:info,*:error"

```

2. Start rest server with unlocked key to send tx to test functionality
```
emintcli rest-server --laddr "tcp://localhost:8545" --unlock-key austineth
```

3. Send a transaction to get values to query:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from":"0x'$(echo -n $(emintcli emintkeys show austineth -w))'","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","gas":"0x76c0","gasPrice":"0x12","value":"0x20","data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
{"jsonrpc":"2.0","id":1,"result":"0x68024cf57efb3990ab4be6a28c5dd92281408f2afd82b086edafee96c168493e"}
```

Use returned hash from previous to query tx:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0x68024cf57efb3990ab4be6a28c5dd92281408f2afd82b086edafee96c168493e"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
{"jsonrpc":"2.0","id":1,"result":{"blockHash":"0x048091bc7ddc283f77bfbf91d73c44da58c3df8a9cbc867405d8b7f3daada22f","blockNumber":"0x4","from":"0x9b66024142dc9fdb71e84233cc3c60787b69c47c","gas":"0x76c0","gasPrice":"0x12","hash":"0xa24ccf21bfce52f7e44b3284144724c7b3153c434305f1aff38bc06643764ea3","input":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675","nonce":"0x0","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","transactionIndex":"0x0","value":"0x20","v":"0x2a","r":"0x123d60242d4065685f7c59e0cdd54484ca0a8e7edf17fc462b3601d3332d3de9","s":"0x18c15a9d66cb80d9a1c07eb8838f1070a9039920c78b52da9a0ef8fc337cd2a6"}}
```

note: should return null if invalid hash provided