### PR TITLE
eth_getTransactionReceipt Impl

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -476,9 +476,6 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 	if !ok || err != nil {
 		return nil, fmt.Errorf("Invalid transaction type, must be an amino encoded Ethereum transaction")
 	}
-	if err != nil {
-		return nil, err
-	}
 
 	from, _ := ethTx.VerifySig(ethTx.ChainID())
 

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -462,7 +462,7 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 		return nil, nil
 	}
 
-	// Can either cache or just leave this out if not necessary
+	// Query block for consensus hash
 	block, err := e.cliCtx.Client.Block(&tx.Height)
 	if err != nil {
 		return nil, err
@@ -495,7 +495,7 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 		"from":              from,
 		"to":                ethTx.To(),
 		"gasUsed":           hexutil.Uint64(tx.TxResult.GasUsed),
-		"cumulativeGasUsed": hexutil.Uint64(0), // TODO: determine if necessary
+		"cumulativeGasUsed": nil, // ignore until needed
 		"contractAddress":   nil,
 		"logs":              nil, // TODO: Do with #55 (eth_getLogs output)
 		"logsBloom":         nil,

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -490,7 +490,7 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 		status = hexutil.Uint(0)
 	}
 
-	return map[string]interface{}{
+	fields := map[string]interface{}{
 		"blockHash":         blockHash,
 		"blockNumber":       hexutil.Uint64(tx.Height),
 		"transactionHash":   hash,
@@ -499,11 +499,17 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 		"to":                ethTx.To(),
 		"gasUsed":           hexutil.Uint64(tx.TxResult.GasUsed),
 		"cumulativeGasUsed": hexutil.Uint64(0), // TODO: determine if necessary
-		"contractAddress":   hexutil.Bytes(tx.TxResult.GetData()),
-		"logs":              tx.TxResult.Log, // TODO: Do with #55 (eth_getLogs output)
+		"contractAddress":   nil,
+		"logs":              nil, // TODO: Do with #55 (eth_getLogs output)
 		"logsBloom":         nil,
 		"status":            status,
-	}, nil
+	}
+
+	if common.BytesToAddress(tx.TxResult.GetData()) != (common.Address{}) {
+		fields["contractAddress"] = hexutil.Bytes(tx.TxResult.GetData())
+	}
+
+	return fields, nil
 }
 
 // GetUncleByBlockHashAndIndex returns the uncle identified by hash and index. Always returns nil.

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -518,12 +518,10 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 	}
 	blockHash := common.BytesToHash(block.BlockMeta.Header.ConsensusHash)
 
-	// Change to conversion function when merged
-	var stdTx sdk.Tx
-	err = e.cliCtx.Codec.UnmarshalBinaryLengthPrefixed(tx.Tx, &stdTx)
-	ethTx, ok := stdTx.(*types.EthereumTxMsg)
-	if !ok || err != nil {
-		return nil, fmt.Errorf("Invalid transaction type, must be an amino encoded Ethereum transaction")
+	// Convert tx bytes to eth transaction
+	ethTx, err := bytesToEthTx(e.cliCtx, tx.Tx)
+	if err != nil {
+		return nil, err
 	}
 
 	from, _ := ethTx.VerifySig(ethTx.ChainID())

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -106,7 +106,7 @@ func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk
 
 	// TODO: Consume gas from sender
 
-	return sdk.Result{Log: addr.Hex(), GasUsed: msg.Data.GasLimit - leftOverGas}
+	return sdk.Result{Data: addr.Bytes(), GasUsed: msg.Data.GasLimit - leftOverGas}
 }
 
 func refundGas(


### PR DESCRIPTION
- Will implement #45 

Missing details:
- Convenience function(s) once #108 comes in
- Cumulative gas (tendermint doesn't track this)
- Logs (which will be completed with eth_getLogs)

To test:
1. Run the Ethermint node:
```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id 3
emintcli config chain-id 3
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli keys add austin
testpass
testpass
emintcli emintkeys add austineth
testpass
testpass
emintd add-genesis-account $(emintcli keys show austin -a) 1000photon,100000000stake
emintd add-genesis-account $(emintcli emintkeys show austineth -a) 100000000photon,100000000stake
emintd gentx --name austin
testpass
emintd collect-gentxs
emintd validate-genesis
emintd start --pruning=nothing --rpc.unsafe --log_level "main:info,state:info,mempool:info,*:error"

```

2. Start rest server with unlocked key to send tx to test functionality
```
emintcli rest-server --laddr "tcp://localhost:8545" --unlock-key austineth
```

3. Send a create contract transaction:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from":"0x'$(echo -n $(emintcli emintkeys show austineth -w))'","data":"0x608060405234801561001057600080fd5b5060c68061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060325760003560e01c806360fe47b11460375780636d4ce63c146062575b600080fd5b606060048036036020811015604b57600080fd5b8101908080359060200190929190505050607e565b005b60686088565b6040518082815260200191505060405180910390f35b8060008190555050565b6000805490509056fea265627a7a72315820c7a7e89d50fdaf002a82feadcf5da419024a5b015898cce54bbf573edcd279f064736f6c634300050b0032","gas":"0x76c11"}],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
## result: {"jsonrpc":"2.0","id":1,"result":"0xc42f7a63e115e1efdfc1878c217a46c1fdaa874c27b2d1ab37dbedad563e064d"}
```

Query contract creation tx:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xc42f7a63e115e1efdfc1878c217a46c1fdaa874c27b2d1ab37dbedad563e064d"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
## result: {"jsonrpc":"2.0","id":1,"result":{"blockHash":"0x048091bc7ddc283f77bfbf91d73c44da58c3df8a9cbc867405d8b7f3daada22f","blockNumber":"0x2","contractAddress":"0x9c6073b69119ef3c23f3114199a6117f9b5c8bb5","cumulativeGasUsed":"0x0","from":"0x7bc6f37a52637dcf6d8fb7c88275c6f874fab319","gasUsed":"0x2250a","logs":null,"logsBloom":null,"status":"0x1","to":null,"transactionHash":"0xc42f7a63e115e1efdfc1878c217a46c1fdaa874c27b2d1ab37dbedad563e064d","transactionIndex":"0x0"}}
```

4. Try with standard transaction:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"from":"0x'$(echo -n $(emintcli emintkeys show austineth -w))'","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","gas":"0x76c0","gasPrice":"0x12","value":"0x20","data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
## res: {"jsonrpc":"2.0","id":1,"result":"0x5de974dd22ab16b411e0201e18148140b6b76451417dc91a0289477ef96a700a"}
```

Query transaction:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x5de974dd22ab16b411e0201e18148140b6b76451417dc91a0289477ef96a700a"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
## res: {"jsonrpc":"2.0","id":1,"result":{"blockHash":"0x048091bc7ddc283f77bfbf91d73c44da58c3df8a9cbc867405d8b7f3daada22f","blockNumber":"0x3","contractAddress":null,"cumulativeGasUsed":"0x0","from":"0x6b92c1c6c8db437352b2b341e463cfcce864c2ec","gasUsed":"0x20245","logs":null,"logsBloom":null,"status":"0x1","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","transactionHash":"0x5de974dd22ab16b411e0201e18148140b6b76451417dc91a0289477ef96a700a","transactionIndex":"0x0"}}
```