### PR TITLE
Implements net_version for Ethers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	golang.org/x/text v0.3.2 // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190708153700-3bdd9d9f5532 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.2.2

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -36,5 +36,11 @@ func GetRPCAPIs(cliCtx context.CLIContext, key emintcrypto.PrivKeySecp256k1) []r
 			Service:   NewPublicFilterAPI(cliCtx),
 			Public:    true,
 		},
+		{
+			Namespace: "net",
+			Version:   "1.0",
+			Service:   NewPublicNetAPI(cliCtx),
+			Public:    true,
+		},
 	}
 }

--- a/rpc/net_api.go
+++ b/rpc/net_api.go
@@ -1,0 +1,34 @@
+package rpc
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/viper"
+)
+
+// PublicNetAPI is the eth_ prefixed set of APIs in the Web3 JSON-RPC spec.
+type PublicNetAPI struct {
+	networkVersion uint64
+}
+
+// NewPersonalEthAPI creates an instance of the public ETH Web3 API.
+func NewPublicNetAPI(cliCtx context.CLIContext) *PublicNetAPI {
+	chainID := viper.GetString(flags.FlagChainID)
+	// parse the chainID from a integer string
+	intChainID, err := strconv.ParseUint(chainID, 0, 64)
+	if err != nil {
+		panic(fmt.Sprintf("Invalid chainID: %s, must be integer format", chainID))
+	}
+
+	return &PublicNetAPI{
+		networkVersion: intChainID,
+	}
+}
+
+// Version returns the current ethereum protocol version.
+func (s *PublicNetAPI) Version() string {
+	return fmt.Sprintf("%d", s.networkVersion)
+}

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -427,7 +427,7 @@ func GenerateFromArgs(args args.SendTxArgs, ctx context.CLIContext) (msg *Ethere
 	if args.Gas == nil {
 		// Estimate the gas usage if necessary.
 		// TODO: Set gas based on estimate when simulating txs are setup
-		gasLimit = 22000
+		gasLimit = 60000
 	} else {
 		gasLimit = (uint64)(*args.Gas)
 	}


### PR DESCRIPTION
- Implements net_version value based on chainID value (Ethers queries net version before sending transaction)
- Increased temporary gas limit value for usability in testing