### PR TITLE
Implements eth_getProof

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	golang.org/x/text v0.3.2 // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190708153700-3bdd9d9f5532 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.2.2

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -600,7 +600,7 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 		return nil, err
 	}
 
-	var logs types.QueryTxLogs
+	var logs types.QueryETHLogs
 	e.cliCtx.Codec.MustUnmarshalJSON(res, &logs)
 
 	// TODO: change hard coded indexing of bytes

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cosmos/ethermint/x/evm"
 	"github.com/cosmos/ethermint/x/evm/types"
 
+	"github.com/tendermint/tendermint/rpc/client"
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -637,6 +638,68 @@ func (e *PublicEthAPI) GetUncleByBlockHashAndIndex(hash common.Hash, idx hexutil
 // GetUncleByBlockNumberAndIndex returns the uncle identified by number and index. Always returns nil.
 func (e *PublicEthAPI) GetUncleByBlockNumberAndIndex(number hexutil.Uint, idx hexutil.Uint) map[string]interface{} {
 	return nil
+}
+
+// AccountResult struct for account proof
+type AccountResult struct {
+	Address      common.Address  `json:"address"`
+	AccountProof []string        `json:"accountProof"`
+	Balance      *hexutil.Big    `json:"balance"`
+	CodeHash     common.Hash     `json:"codeHash"`
+	Nonce        hexutil.Uint64  `json:"nonce"`
+	StorageHash  common.Hash     `json:"storageHash"`
+	StorageProof []StorageResult `json:"storageProof"`
+}
+
+// StorageResult defines the format for storage proof return
+type StorageResult struct {
+	Key   string       `json:"key"`
+	Value *hexutil.Big `json:"value"`
+	Proof []string     `json:"proof"`
+}
+
+// GetProof returns an account object with proof and any storage proofs
+func (e *PublicEthAPI) GetProof(address common.Address, storageKeys []string, block BlockNumber) (*AccountResult, error) {
+	opts := client.ABCIQueryOptions{Height: int64(block), Prove: true}
+	path := fmt.Sprintf("custom/%s/%s/%s", types.ModuleName, evm.QueryAccount, address.Hex())
+	pRes, err := e.cliCtx.Client.ABCIQueryWithOptions(path, nil, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: convert TM merkle proof to []string if needed in future
+	// proof := pRes.Response.GetProof()
+
+	account := new(types.QueryAccount)
+	e.cliCtx.Codec.MustUnmarshalJSON(pRes.Response.GetValue(), &account)
+
+	storageProofs := make([]StorageResult, len(storageKeys))
+	for i, k := range storageKeys {
+		// Get value for key
+		vPath := fmt.Sprintf("custom/%s/%s/%s/%s", types.ModuleName, evm.QueryStorage, address, k)
+		vRes, err := e.cliCtx.Client.ABCIQueryWithOptions(vPath, nil, opts)
+		if err != nil {
+			return nil, err
+		}
+		value := new(types.QueryResStorage)
+		e.cliCtx.Codec.MustUnmarshalJSON(vRes.Response.GetValue(), &value)
+
+		storageProofs[i] = StorageResult{
+			Key:   k,
+			Value: (*hexutil.Big)(common.BytesToHash(value.Value).Big()),
+			Proof: []string{""},
+		}
+	}
+
+	return &AccountResult{
+		Address:      address,
+		AccountProof: []string{""}, // This shouldn't be necessary (different proof formats)
+		Balance:      (*hexutil.Big)(utils.MustUnmarshalBigInt(account.Balance)),
+		CodeHash:     common.BytesToHash(account.CodeHash),
+		Nonce:        hexutil.Uint64(account.Nonce),
+		StorageHash:  common.Hash{}, // Ethermint doesn't have a storage hash
+		StorageProof: storageProofs,
+	}, nil
 }
 
 // getGasLimit returns the gas limit per block set in genesis

--- a/utils/int.go
+++ b/utils/int.go
@@ -17,3 +17,13 @@ func UnmarshalBigInt(s string) (*big.Int, error) {
 	err := ret.UnmarshalText([]byte(s))
 	return ret, err
 }
+
+// MustUnmarshalBigInt unmarshalls string from *big.Int
+func MustUnmarshalBigInt(s string) *big.Int {
+	ret := new(big.Int)
+	err := ret.UnmarshalText([]byte(s))
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}

--- a/x/evm/querier.go
+++ b/x/evm/querier.go
@@ -25,6 +25,7 @@ const (
 	QueryTxLogs          = "txLogs"
 	QueryLogsBloom       = "logsBloom"
 	QueryLogs            = "logs"
+	QueryAccount         = "account"
 )
 
 // NewQuerier is the module level router for state queries
@@ -50,7 +51,9 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 		case QueryLogsBloom:
 			return queryBlockLogsBloom(ctx, path, keeper)
 		case QueryLogs:
-			return queryLogs(ctx, path, keeper)
+			return queryLogs(ctx, keeper)
+		case QueryAccount:
+			return queryAccount(ctx, path, keeper)
 		default:
 			return nil, sdk.ErrUnknownRequest("unknown query endpoint")
 		}
@@ -171,10 +174,27 @@ func queryTxLogs(ctx sdk.Context, path []string, keeper Keeper) ([]byte, sdk.Err
 	return res, nil
 }
 
-func queryLogs(ctx sdk.Context, path []string, keeper Keeper) ([]byte, sdk.Error) {
+func queryLogs(ctx sdk.Context, keeper Keeper) ([]byte, sdk.Error) {
 	logs := keeper.Logs(ctx)
 
-	l, err := codec.MarshalJSONIndent(keeper.cdc, logs)
+	lRes := types.QueryTxLogs{Logs: logs}
+	l, err := codec.MarshalJSONIndent(keeper.cdc, lRes)
+	if err != nil {
+		panic("could not marshal result to JSON: " + err.Error())
+	}
+	return l, nil
+}
+
+func queryAccount(ctx sdk.Context, path []string, keeper Keeper) ([]byte, sdk.Error) {
+	addr := ethcmn.HexToAddress(path[1])
+	so := keeper.GetOrNewStateObject(ctx, addr)
+
+	lRes := types.QueryAccount{
+		Balance:  utils.MarshalBigInt(so.Balance()),
+		CodeHash: so.CodeHash(),
+		Nonce:    so.Nonce(),
+	}
+	l, err := codec.MarshalJSONIndent(keeper.cdc, lRes)
 	if err != nil {
 		panic("could not marshal result to JSON: " + err.Error())
 	}

--- a/x/evm/querier.go
+++ b/x/evm/querier.go
@@ -165,7 +165,7 @@ func queryTxLogs(ctx sdk.Context, path []string, keeper Keeper) ([]byte, sdk.Err
 	txHash := ethcmn.HexToHash(path[1])
 	logs := keeper.GetLogs(ctx, txHash)
 
-	bRes := types.QueryTxLogs{Logs: logs}
+	bRes := types.QueryETHLogs{Logs: logs}
 	res, err := codec.MarshalJSONIndent(keeper.cdc, bRes)
 	if err != nil {
 		panic("could not marshal result to JSON: " + err.Error())
@@ -177,7 +177,7 @@ func queryTxLogs(ctx sdk.Context, path []string, keeper Keeper) ([]byte, sdk.Err
 func queryLogs(ctx sdk.Context, keeper Keeper) ([]byte, sdk.Error) {
 	logs := keeper.Logs(ctx)
 
-	lRes := types.QueryTxLogs{Logs: logs}
+	lRes := types.QueryETHLogs{Logs: logs}
 	l, err := codec.MarshalJSONIndent(keeper.cdc, lRes)
 	if err != nil {
 		panic("could not marshal result to JSON: " + err.Error())

--- a/x/evm/types/querier.go
+++ b/x/evm/types/querier.go
@@ -60,12 +60,12 @@ func (q QueryResNonce) String() string {
 	return string(q.Nonce)
 }
 
-// QueryTxLogs is response type for tx logs query
-type QueryTxLogs struct {
+// QueryETHLogs is response type for tx logs query
+type QueryETHLogs struct {
 	Logs []*ethtypes.Log `json:"logs"`
 }
 
-func (q QueryTxLogs) String() string {
+func (q QueryETHLogs) String() string {
 	return string(fmt.Sprintf("%+v", q.Logs))
 }
 

--- a/x/evm/types/querier.go
+++ b/x/evm/types/querier.go
@@ -77,3 +77,10 @@ type QueryBloomFilter struct {
 func (q QueryBloomFilter) String() string {
 	return string(q.Bloom.Bytes())
 }
+
+// QueryAccount is response type for querying Ethereum state objects
+type QueryAccount struct {
+	Balance  string `json:"balance"`
+	CodeHash []byte `json:"codeHash"`
+	Nonce    uint64 `json:"nonce"`
+}


### PR DESCRIPTION
- Implements #56 Get account/ storage proof
- Cleaned up query type for queryLogs

Notes:
- Proofs are very different in Tendermint due to the completely different merkle tree structures so it is ommitted from this PR, but the code is set up to have the TM proof available to be converted if a usable equivalent needs and can be established. Only account and storage data is returned from this endpoint currently.

To test:
1. Start node (commands I used):
```
make install 
rm -rf ~/.emint*
emintd init moniker --chain-id 3
emintcli config chain-id 3
emintcli config output json
emintcli config indent true
emintcli config trust-node true
emintcli keys add austin
testpass
testpass
emintcli emintkeys add austineth
testpass
testpass
emintd add-genesis-account $(emintcli keys show austin -a) 1000photon,100000000stake
emintd add-genesis-account $(emintcli emintkeys show austineth -a) 100000000photon,100000000stake
emintd gentx --name austin
testpass
emintd collect-gentxs
emintd validate-genesis
emintd start --pruning=nothing --rpc.unsafe --log_level "main:info,state:info,mempool:info,*:error"

```

2. Run any transactions to test values

3. Querying empty accounts:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getProof","params":["0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842",["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"],"latest"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
# response: {"jsonrpc":"2.0","id":1,"result":{"address":"0x7f0d15c7faae65896648c8273b6d7e43f58fa842","accountProof":[""],"balance":"0x0","codeHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","storageHash":"0x0000000000000000000000000000000000000000000000000000000000000000","storageProof":[{"key":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","value":"0x0","proof":[""]}]}}
```

4. Query unlocked key account:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getProof","params":["0x'$(echo -n $(emintcli emintkeys show austineth -w))'",["0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"],"latest"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
# response: {"jsonrpc":"2.0","id":1,"result":{"address":"0x0902e6b7719cd5710341bdb3dd78dd7ca8683677","accountProof":[""],"balance":"0x3b9aca00","codeHash":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470","nonce":"0x1","storageHash":"0x0000000000000000000000000000000000000000000000000000000000000000","storageProof":[{"key":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","value":"0x0","proof":[""]}]}}
```