### PR TITLE
Gas usage implementation

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -244,9 +244,6 @@ func ethAnteHandler(
 		if !res.IsOK() {
 			return ctx, res, true
 		}
-
-		// Reload account after fees deducted
-		senderAcc = ak.GetAccount(ctx, senderAcc.GetAddress())
 	}
 
 	// Set gas meter after ante handler to ignore gaskv costs

--- a/app/ante.go
+++ b/app/ante.go
@@ -287,12 +287,6 @@ func validateEthTxCheckTx(
 		return nil, res
 	}
 
-	acc := ak.GetAccount(ctx, signer)
-	err := acc.SetSequence(acc.GetSequence() + 1)
-	if err != nil {
-		return nil, sdk.ErrInternal("failed to set account nonce").Result()
-	}
-
 	return sdk.AccAddress(signer.Bytes()), sdk.Result{}
 }
 

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -117,7 +117,11 @@ func (am AppModule) BeginBlock(ctx sdk.Context, bl abci.RequestBeginBlock) {
 
 // EndBlock function for module at end of block
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
-	_, err := am.keeper.csdb.Commit(true)
+	// Gas costs are handled within msg handler so costs should be ignored
+	ebCtx := ctx.WithBlockGasMeter(sdk.NewInfiniteGasMeter())
+
+	// Commit state objects to KV store
+	_, err := am.keeper.csdb.WithContext(ebCtx).Commit(true)
 	if err != nil {
 		panic(err)
 	}

--- a/x/evm/types/state_transition.go
+++ b/x/evm/types/state_transition.go
@@ -48,7 +48,7 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (sdk.Result, *big.Int)
 	}
 
 	// This gas meter is set up to consume gas from gaskv during evm execution and be ignored
-	evmGasMeter := sdk.NewGasMeter(gasLimit)
+	evmGasMeter := sdk.NewInfiniteGasMeter()
 
 	vmenv := vm.NewEVM(
 		context, st.Csdb.WithContext(ctx.WithGasMeter(evmGasMeter)),

--- a/x/evm/types/state_transition.go
+++ b/x/evm/types/state_transition.go
@@ -31,6 +31,9 @@ type StateTransition struct {
 func (st StateTransition) TransitionCSDB(ctx sdk.Context) (sdk.Result, *big.Int) {
 	contractCreation := st.Recipient == nil
 
+	// This gas limit the the transaction gas limit with intrinsic gas subtracted
+	gasLimit := ctx.GasMeter().Limit()
+
 	// Create context for evm
 	context := vm.Context{
 		CanTransfer: core.CanTransfer,
@@ -40,11 +43,17 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (sdk.Result, *big.Int)
 		BlockNumber: big.NewInt(ctx.BlockHeight()),
 		Time:        big.NewInt(time.Now().Unix()),
 		Difficulty:  big.NewInt(0x30000), // unused
-		GasLimit:    ctx.GasMeter().Limit(),
+		GasLimit:    gasLimit,
 		GasPrice:    ctx.MinGasPrices().AmountOf(emint.DenomDefault).Int,
 	}
 
-	vmenv := vm.NewEVM(context, st.Csdb.WithContext(ctx), GenerateChainConfig(st.ChainID), vm.Config{})
+	// This gas meter is set up to consume gas from gaskv during evm execution and be ignored
+	evmGasMeter := sdk.NewGasMeter(gasLimit)
+
+	vmenv := vm.NewEVM(
+		context, st.Csdb.WithContext(ctx.WithGasMeter(evmGasMeter)),
+		GenerateChainConfig(st.ChainID), vm.Config{},
+	)
 
 	var (
 		leftOverGas uint64
@@ -54,11 +63,11 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (sdk.Result, *big.Int)
 	)
 
 	if contractCreation {
-		_, addr, leftOverGas, vmerr = vmenv.Create(senderRef, st.Payload, st.GasLimit, st.Amount)
+		_, addr, leftOverGas, vmerr = vmenv.Create(senderRef, st.Payload, gasLimit, st.Amount)
 	} else {
 		// Increment the nonce for the next transaction
 		st.Csdb.SetNonce(st.Sender, st.Csdb.GetNonce(st.Sender)+1)
-		_, leftOverGas, vmerr = vmenv.Call(senderRef, *st.Recipient, st.Payload, st.GasLimit, st.Amount)
+		_, leftOverGas, vmerr = vmenv.Call(senderRef, *st.Recipient, st.Payload, gasLimit, st.Amount)
 	}
 
 	// handle errors
@@ -66,15 +75,13 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (sdk.Result, *big.Int)
 		return emint.ErrVMExecution(vmerr.Error()).Result(), nil
 	}
 
-	// Refund remaining gas from tx (Check these values and ensure gas is being consumed correctly)
-	refundGas(st.Csdb, &leftOverGas, st.GasLimit, context.GasPrice, st.Sender)
-
-	// add balance for the processor of the tx (determine who rewards are being processed to)
-	// TODO: Double check nothing needs to be done here
+	// Refunds would happen here, if intended in future
 
 	st.Csdb.Finalise(true) // Change to depend on config
 
-	// TODO: Consume gas from sender
+	// Consume gas from evm execution
+	// Out of gas check does not need to be done here since it is done within the EVM execution
+	ctx.GasMeter().ConsumeGas(gasLimit-leftOverGas, "EVM execution consumption")
 
 	// Generate bloom filter to be saved in tx receipt data
 	bloomInt := big.NewInt(0)
@@ -89,25 +96,4 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (sdk.Result, *big.Int)
 	returnData := append(addr.Bytes(), bloomFilter.Bytes()...)
 
 	return sdk.Result{Data: returnData, GasUsed: st.GasLimit - leftOverGas}, bloomInt
-}
-
-func refundGas(
-	st vm.StateDB, gasRemaining *uint64, initialGas uint64, gasPrice *big.Int,
-	from common.Address,
-) {
-	// Apply refund counter, capped to half of the used gas.
-	refund := (initialGas - *gasRemaining) / 2
-	if refund > st.GetRefund() {
-		refund = st.GetRefund()
-	}
-	*gasRemaining += refund
-
-	// // Return ETH for remaining gas, exchanged at the original rate.
-	// remaining := new(big.Int).Mul(new(big.Int).SetUint64(*gasRemaining), gasPrice)
-	// st.AddBalance(from, remaining)
-
-	// // Also return remaining gas to the block gas counter so it is
-	// // available for the next transaction.
-	// TODO: Return gas to block gas meter?
-	// st.gp.AddGas(st.gas)
 }


### PR DESCRIPTION
- Pays fees to validators in ante handler based on gas limit
- Ignores gaskv gas consumption by attaching an infinite gas meter to the context used when implicit reads and writes would be charged to the gas meter actually being used (let me know if this is confusing but is a necessary workaround to avoid forking Cosmos or removing costs for any operation outside of the evm execution)
  - Will look like `.WithBlockGasMeter(sdk.NewInfiniteGasMeter())` or something similar
- Consume gas using sdk gas meter to accurately indicate amount of gas used in transaction

Issues that remain with this:
- fees are not properly paid after first transaction (was an issue before but was not considered because the hacky workaround that caused this was necessary)
- Refunds can't currently happen in the Cosmos-sdk framework, but can look into a solution or workaround later (wanted to separate from this PR since the refund is not crucial since it is how Cosmos handles paying for transactions currently)

I will continue to find a good way around the first issue I reference, but the solution would be logically different so should probably come in another PR (fix will affect the genesis utils and `newObject(...)` in the evm module) so this could be merged in. Just would be nice to get another set of eyes on this to see if there is a better way to handle any of this stuff.