### PR TITLE
Tx receipt query fix

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -605,8 +605,14 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 	var logs types.QueryETHLogs
 	e.cliCtx.Codec.MustUnmarshalJSON(res, &logs)
 
-	// TODO: change hard coded indexing of bytes
-	bloomFilter := ethtypes.BytesToBloom(tx.TxResult.GetData()[20:])
+	txData := tx.TxResult.GetData()
+	var bloomFilter ethtypes.Bloom
+	var contractAddress common.Address
+	if len(txData) >= 20 {
+		// TODO: change hard coded indexing of bytes
+		bloomFilter = ethtypes.BytesToBloom(txData[20:])
+		contractAddress = common.BytesToAddress(txData[:20])
+	}
 
 	fields := map[string]interface{}{
 		"blockHash":         blockHash,
@@ -623,7 +629,6 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 		"status":            status,
 	}
 
-	contractAddress := common.BytesToAddress(tx.TxResult.GetData()[:20])
 	if contractAddress != (common.Address{}) {
 		// TODO: change hard coded indexing of first 20 bytes
 		fields["contractAddress"] = contractAddress

--- a/x/evm/types/state_transition.go
+++ b/x/evm/types/state_transition.go
@@ -93,7 +93,7 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (sdk.Result, *big.Int)
 		return res, nil
 	}
 
-	// Refunds would happen here, if intended in future
+	// TODO: Refund unused gas here, if intended in future
 
 	st.Csdb.Finalise(true) // Change to depend on config
 


### PR DESCRIPTION
- Fixes unhandled error on getting tx receipt of failed tx (was referencing bytes out of range, would have been fixed with changing how data is returned later anyway)
- Adds logs bloom to data on transaction that runs into a VM error