### PR TITLE
Implements eth_call

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -2,13 +2,17 @@ package rpc
 
 import (
 	"bytes"
+	baseContext "context"
 	"fmt"
+	"log"
 	"math/big"
 	"strconv"
+	"time"
 
 	emintcrypto "github.com/cosmos/ethermint/crypto"
 	emintkeys "github.com/cosmos/ethermint/keys"
 	"github.com/cosmos/ethermint/rpc/args"
+	emint "github.com/cosmos/ethermint/types"
 	"github.com/cosmos/ethermint/utils"
 	"github.com/cosmos/ethermint/version"
 	"github.com/cosmos/ethermint/x/evm"
@@ -21,12 +25,15 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authutils "github.com/cosmos/cosmos-sdk/x/auth/client/utils"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/spf13/viper"
 )
@@ -324,19 +331,120 @@ func (e *PublicEthAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, erro
 	return common.HexToHash(res.TxHash), nil
 }
 
-// CallArgs represents arguments to a smart contract call as provided by RPC clients.
+// CallArgs represents the arguments for a call.
 type CallArgs struct {
-	From     common.Address `json:"from"`
-	To       common.Address `json:"to"`
-	Gas      hexutil.Uint64 `json:"gas"`
-	GasPrice hexutil.Big    `json:"gasPrice"`
-	Value    hexutil.Big    `json:"value"`
-	Data     hexutil.Bytes  `json:"data"`
+	From     *common.Address `json:"from"`
+	To       *common.Address `json:"to"`
+	Gas      *hexutil.Uint64 `json:"gas"`
+	GasPrice *hexutil.Big    `json:"gasPrice"`
+	Value    *hexutil.Big    `json:"value"`
+	Data     *hexutil.Bytes  `json:"data"`
 }
 
 // Call performs a raw contract call.
-func (e *PublicEthAPI) Call(args CallArgs, blockNum BlockNumber) hexutil.Bytes {
-	return nil
+func (e *PublicEthAPI) Call(ctx baseContext.Context, args CallArgs, blockNr rpc.BlockNumber, overrides *map[common.Address]account) (hexutil.Bytes, error) {
+	result, err := e.doCall(args, blockNr, vm.Config{}, big.NewInt(emint.DefaultRPCGasLimit))
+	return (hexutil.Bytes)(result), err
+}
+
+// account indicates the overriding fields of account during the execution of
+// a message call.
+// Note, state and stateDiff can't be specified at the same time. If state is
+// set, message execution will only use the data in the given state. Otherwise
+// if statDiff is set, all diff will be applied first and then execute the call
+// message.
+type account struct {
+	Nonce     *hexutil.Uint64              `json:"nonce"`
+	Code      *hexutil.Bytes               `json:"code"`
+	Balance   **hexutil.Big                `json:"balance"`
+	State     *map[common.Hash]common.Hash `json:"state"`
+	StateDiff *map[common.Hash]common.Hash `json:"stateDiff"`
+}
+
+// DoCall performs a simulated call operation through the evm
+func (e *PublicEthAPI) doCall(args CallArgs, blockNr rpc.BlockNumber, vmCfg vm.Config, globalGasCap *big.Int) ([]byte, error) {
+	defer func(start time.Time) { log.Println("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Println(err)
+		}
+	}()
+
+	// Set height for historical queries
+	ctx := e.cliCtx.WithHeight(blockNr.Int64())
+
+	// Set sender address or use a default if none specified
+	var addr common.Address
+	if args.From == nil {
+		if e.key != nil {
+			addr = common.BytesToAddress(e.key.PubKey().Address().Bytes())
+		}
+		// No error handled here intentionally to match geth behaviour
+	} else {
+		addr = *args.From
+	}
+
+	// Set default gas & gas price if none were set
+	// Change this to uint64(math.MaxUint64 / 2) if gas cap can be configured
+	gas := uint64(emint.DefaultRPCGasLimit)
+	if args.Gas != nil {
+		gas = uint64(*args.Gas)
+	}
+	if globalGasCap != nil && globalGasCap.Uint64() < gas {
+		log.Println("Caller gas above allowance, capping", "requested", gas, "cap", globalGasCap)
+		gas = globalGasCap.Uint64()
+	}
+
+	// Set gas price using default or parameter if passed in
+	gasPrice := new(big.Int).SetUint64(emint.DefaultGasPrice)
+	if args.GasPrice != nil {
+		gasPrice = args.GasPrice.ToInt()
+	}
+
+	// Set value for transaction
+	value := new(big.Int)
+	if args.Value != nil {
+		value = args.Value.ToInt()
+	}
+
+	// Set Data if provided
+	var data []byte
+	if args.Data != nil {
+		data = []byte(*args.Data)
+	}
+
+	// Set destination address for call
+	var toAddr sdk.AccAddress
+	if args.To != nil {
+		toAddr = sdk.AccAddress(args.To.Bytes())
+	}
+
+	// Create new call message
+	msg := types.NewEmintMsg(0, &toAddr, sdk.NewIntFromBigInt(value), gas,
+		sdk.NewIntFromBigInt(gasPrice), data, sdk.AccAddress(addr.Bytes()))
+
+	// Generate tx to be used to simulate (signature isn't needed)
+	tx := authtypes.NewStdTx([]sdk.Msg{msg}, authtypes.StdFee{}, []authtypes.StdSignature{authtypes.StdSignature{}}, "")
+
+	// Encode transaction by default Tx encoder
+	txEncoder := authutils.GetTxEncoder(ctx.Codec)
+	txBytes, err := txEncoder(tx)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	// Transaction simulation through query
+	res, _, err := ctx.QueryWithData("app/simulate", txBytes)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	var simResult sdk.Result
+	if err = ctx.Codec.UnmarshalBinaryLengthPrefixed(res, &simResult); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 // EstimateGas estimates gas usage for the given smart contract call.

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -605,8 +605,14 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 	var logs types.QueryETHLogs
 	e.cliCtx.Codec.MustUnmarshalJSON(res, &logs)
 
-	// TODO: change hard coded indexing of bytes
-	bloomFilter := ethtypes.BytesToBloom(tx.TxResult.GetData()[20:])
+	txData := tx.TxResult.GetData()
+	var bloomFilter ethtypes.Bloom
+	var contractAddress common.Address
+	if len(txData) >= 20 {
+		// TODO: change hard coded indexing of bytes
+		bloomFilter = ethtypes.BytesToBloom(txData[20:])
+		contractAddress = common.BytesToAddress(txData[:20])
+	}
 
 	fields := map[string]interface{}{
 		"blockHash":         blockHash,
@@ -623,7 +629,6 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 		"status":            status,
 	}
 
-	contractAddress := common.BytesToAddress(tx.TxResult.GetData()[:20])
 	if contractAddress != (common.Address{}) {
 		// TODO: change hard coded indexing of first 20 bytes
 		fields["contractAddress"] = contractAddress

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"bytes"
-	baseContext "context"
 	"fmt"
 	"log"
 	"math/big"
@@ -342,7 +341,7 @@ type CallArgs struct {
 }
 
 // Call performs a raw contract call.
-func (e *PublicEthAPI) Call(ctx baseContext.Context, args CallArgs, blockNr rpc.BlockNumber, overrides *map[common.Address]account) (hexutil.Bytes, error) {
+func (e *PublicEthAPI) Call(args CallArgs, blockNr rpc.BlockNumber, overrides *map[common.Address]account) (hexutil.Bytes, error) {
 	result, err := e.doCall(args, blockNr, vm.Config{}, big.NewInt(emint.DefaultRPCGasLimit))
 	return (hexutil.Bytes)(result), err
 }

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"math/big"
 	"strconv"
-	"time"
 
 	emintcrypto "github.com/cosmos/ethermint/crypto"
 	emintkeys "github.com/cosmos/ethermint/keys"
@@ -362,8 +361,6 @@ type account struct {
 
 // DoCall performs a simulated call operation through the evm
 func (e *PublicEthAPI) doCall(args CallArgs, blockNr rpc.BlockNumber, vmCfg vm.Config, globalGasCap *big.Int) ([]byte, error) {
-	defer func(start time.Time) { log.Println("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
-
 	// Set height for historical queries
 	ctx := e.cliCtx.WithHeight(blockNr.Int64())
 

--- a/types/params.go
+++ b/types/params.go
@@ -1,0 +1,8 @@
+package types
+
+const (
+	// DefaultGasPrice is default gas price for evm transactions
+	DefaultGasPrice = 20
+	// DefaultRPCGasLimit is default gas limit for RPC call operations
+	DefaultRPCGasLimit = 10000000
+)

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -20,8 +20,8 @@ func NewHandler(keeper Keeper) sdk.Handler {
 		switch msg := msg.(type) {
 		case types.EthereumTxMsg:
 			return handleETHTxMsg(ctx, keeper, msg)
-		case types.EmintMsg:
-			return handleEmintMsg(ctx, keeper, msg)
+		case *types.EmintMsg:
+			return handleEmintMsg(ctx, keeper, *msg)
 		default:
 			errMsg := fmt.Sprintf("Unrecognized ethermint Msg type: %v", msg.Type())
 			return sdk.ErrUnknownRequest(errMsg).Result()
@@ -67,6 +67,7 @@ func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk
 		Csdb:         keeper.csdb.WithContext(ctx),
 		ChainID:      intChainID,
 		THash:        &ethHash,
+		Simulate:     ctx.IsCheckTx(),
 	}
 	// Prepare db for logs
 	keeper.csdb.Prepare(ethHash, common.Hash{}, keeper.txCount.get())
@@ -97,6 +98,7 @@ func handleEmintMsg(ctx sdk.Context, keeper Keeper, msg types.EmintMsg) sdk.Resu
 		Payload:      msg.Payload,
 		Csdb:         keeper.csdb.WithContext(ctx),
 		ChainID:      intChainID,
+		Simulate:     ctx.IsCheckTx(),
 	}
 
 	if msg.Recipient != nil {

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -391,7 +391,7 @@ func GenerateFromArgs(args args.SendTxArgs, ctx context.CLIContext) (msg *Ethere
 	if args.GasPrice == nil {
 		// Set default gas price
 		// TODO: Change to min gas price from context once available through server/daemon
-		gasPrice = big.NewInt(20)
+		gasPrice = big.NewInt(types.DefaultGasPrice)
 	}
 
 	if args.Nonce == nil {

--- a/x/evm/types/state_transition.go
+++ b/x/evm/types/state_transition.go
@@ -25,6 +25,7 @@ type StateTransition struct {
 	Csdb         *CommitStateDB
 	ChainID      *big.Int
 	THash        *common.Hash
+	Simulate     bool
 }
 
 // TransitionCSDB performs an evm state transition from a transaction
@@ -105,12 +106,15 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (sdk.Result, *big.Int)
 }
 
 func (st *StateTransition) checkNonce() sdk.Result {
-	// Make sure this transaction's nonce is correct.
-	nonce := st.Csdb.GetNonce(st.Sender)
-	if nonce < st.AccountNonce {
-		return emint.ErrInvalidNonce("nonce too high").Result()
-	} else if nonce > st.AccountNonce {
-		return emint.ErrInvalidNonce("nonce too low").Result()
+	// If simulated transaction, don't verify nonce
+	if !st.Simulate {
+		// Make sure this transaction's nonce is correct.
+		nonce := st.Csdb.GetNonce(st.Sender)
+		if nonce < st.AccountNonce {
+			return emint.ErrInvalidNonce("nonce too high").Result()
+		} else if nonce > st.AccountNonce {
+			return emint.ErrInvalidNonce("nonce too low").Result()
+		}
 	}
 
 	return sdk.Result{}

--- a/x/evm/types/utils.go
+++ b/x/evm/types/utils.go
@@ -53,7 +53,7 @@ func rlpHash(x interface{}) (hash ethcmn.Hash) {
 	return hash
 }
 
-// GenerateReturnData takes all of the necessary data from the EVM execution
+// EncodeReturnData takes all of the necessary data from the EVM execution
 // and returns the data as a byte slice
 func EncodeReturnData(addr ethcmn.Address, bloom ethtypes.Bloom, evmRet []byte) []byte {
 	// Append address, bloom, evm return bytes in that order

--- a/x/evm/types/utils.go
+++ b/x/evm/types/utils.go
@@ -5,11 +5,17 @@ import (
 
 	"github.com/cosmos/ethermint/crypto"
 	ethcmn "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/sha3"
+)
+
+const (
+	bloomIdx  = ethcmn.AddressLength
+	returnIdx = bloomIdx + ethtypes.BloomByteLength
 )
 
 // GenerateEthAddress generates an Ethereum address.
@@ -45,4 +51,25 @@ func rlpHash(x interface{}) (hash ethcmn.Hash) {
 	hasher.Sum(hash[:0])
 
 	return hash
+}
+
+// GenerateReturnData takes all of the necessary data from the EVM execution
+// and returns the data as a byte slice
+func EncodeReturnData(addr ethcmn.Address, bloom ethtypes.Bloom, evmRet []byte) []byte {
+	// Append address, bloom, evm return bytes in that order
+	returnData := append(addr.Bytes(), bloom.Bytes()...)
+	return append(returnData, evmRet...)
+}
+
+// DecodeReturnData decodes the byte slice of values to their respective types
+func DecodeReturnData(bytes []byte) (addr ethcmn.Address, bloom ethtypes.Bloom, ret []byte, err error) {
+	if len(bytes) >= returnIdx {
+		addr = ethcmn.BytesToAddress(bytes[:bloomIdx])
+		bloom = ethtypes.BytesToBloom(bytes[bloomIdx:returnIdx])
+		ret = bytes[returnIdx:]
+	} else {
+		err = fmt.Errorf("Invalid format for encoded data, message must be an EVM state transition")
+	}
+
+	return
 }

--- a/x/evm/types/utils_test.go
+++ b/x/evm/types/utils_test.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	"testing"
+
+	ethcmn "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvmDataEncoding(t *testing.T) {
+	addr := ethcmn.HexToAddress("0x12345")
+	bloom := ethtypes.BytesToBloom([]byte{0x1, 0x3})
+	ret := []byte{0x5, 0x8}
+
+	encoded := EncodeReturnData(addr, bloom, ret)
+
+	decAddr, decBloom, decRet, err := DecodeReturnData(encoded)
+
+	require.NoError(t, err)
+	require.Equal(t, addr, decAddr)
+	require.Equal(t, bloom, decBloom)
+	require.Equal(t, ret, decRet)
+}


### PR DESCRIPTION
- Implements #38 Simulating transactions with eth_call
- Sets up encoding and decoding for the parameters (created contract address, bloom filter, evm return bytes) for consistency and usability. Address and bloom filter are constant length so no custom encoding necessary

I will remove the first two commits from this PR when #126 comes in

Notes:
- accounts cannot be overriden through this call, as the only parameter is the encoded transaction data
  - Maybe possible in future to be able to create custom query which sets accounts before performing state transition (there becomes an issue with not accurate mapping to regular transactions since it would not pass through the antehandler and no guarantee about logical consistency)

eth_call request to test:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"from":"0x'$(echo -n $(emintcli emintkeys show austineth -w))'","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","gas":"0x76c0","gasPrice":"0x12","value":"0x20","data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}, "latest"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
```

but all parameters are optional and for the most part will be defaulted, the only one necessary being a from address through the unlocked key or passed as a parameter. I will look into deploying and testing eth_call more accurately since manually testing this is tedious.