### PR TITLE
eth_estimateGas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build/
 
 # Goland
 .idea/
+start.sh

--- a/app/ante_test.go
+++ b/app/ante_test.go
@@ -68,7 +68,7 @@ func TestValidEthTx(t *testing.T) {
 	to := ethcmn.BytesToAddress(addr2.Bytes())
 	amt := big.NewInt(32)
 	gas := big.NewInt(20)
-	ethMsg := evmtypes.NewEthereumTxMsg(0, to, amt, 22000, gas, []byte("test"))
+	ethMsg := evmtypes.NewEthereumTxMsg(0, &to, amt, 22000, gas, []byte("test"))
 
 	tx := newTestEthTx(input.ctx, ethMsg, priv1)
 	requireValidTx(t, input.anteHandler, input.ctx, tx, false)
@@ -204,7 +204,7 @@ func TestEthInvalidSig(t *testing.T) {
 	to := ethcmn.BytesToAddress(addr2.Bytes())
 	amt := big.NewInt(32)
 	gas := big.NewInt(20)
-	ethMsg := evmtypes.NewEthereumTxMsg(0, to, amt, 22000, gas, []byte("test"))
+	ethMsg := evmtypes.NewEthereumTxMsg(0, &to, amt, 22000, gas, []byte("test"))
 
 	tx := newTestEthTx(input.ctx, ethMsg, priv1)
 	ctx := input.ctx.WithChainID("4")
@@ -229,7 +229,7 @@ func TestEthInvalidNonce(t *testing.T) {
 	to := ethcmn.BytesToAddress(addr2.Bytes())
 	amt := big.NewInt(32)
 	gas := big.NewInt(20)
-	ethMsg := evmtypes.NewEthereumTxMsg(0, to, amt, 22000, gas, []byte("test"))
+	ethMsg := evmtypes.NewEthereumTxMsg(0, &to, amt, 22000, gas, []byte("test"))
 
 	tx := newTestEthTx(input.ctx, ethMsg, priv1)
 	requireInvalidTx(t, input.anteHandler, input.ctx, tx, false, sdk.CodeInvalidSequence)
@@ -249,7 +249,7 @@ func TestEthInsufficientBalance(t *testing.T) {
 	to := ethcmn.BytesToAddress(addr2.Bytes())
 	amt := big.NewInt(32)
 	gas := big.NewInt(20)
-	ethMsg := evmtypes.NewEthereumTxMsg(0, to, amt, 22000, gas, []byte("test"))
+	ethMsg := evmtypes.NewEthereumTxMsg(0, &to, amt, 22000, gas, []byte("test"))
 
 	tx := newTestEthTx(input.ctx, ethMsg, priv1)
 	requireInvalidTx(t, input.anteHandler, input.ctx, tx, false, sdk.CodeInsufficientFunds)
@@ -272,7 +272,7 @@ func TestEthInvalidIntrinsicGas(t *testing.T) {
 	amt := big.NewInt(32)
 	gas := big.NewInt(20)
 	gasLimit := uint64(1000)
-	ethMsg := evmtypes.NewEthereumTxMsg(0, to, amt, gasLimit, gas, []byte("test"))
+	ethMsg := evmtypes.NewEthereumTxMsg(0, &to, amt, gasLimit, gas, []byte("test"))
 
 	tx := newTestEthTx(input.ctx, ethMsg, priv1)
 	requireInvalidTx(t, input.anteHandler, input.ctx, tx, false, sdk.CodeInternal)
@@ -295,7 +295,7 @@ func TestEthInvalidMempoolFees(t *testing.T) {
 	to := ethcmn.BytesToAddress(addr2.Bytes())
 	amt := big.NewInt(32)
 	gas := big.NewInt(20)
-	ethMsg := evmtypes.NewEthereumTxMsg(0, to, amt, 22000, gas, []byte("test"))
+	ethMsg := evmtypes.NewEthereumTxMsg(0, &to, amt, 22000, gas, []byte("test"))
 
 	tx := newTestEthTx(input.ctx, ethMsg, priv1)
 	requireInvalidTx(t, input.anteHandler, input.ctx, tx, false, sdk.CodeInsufficientFee)
@@ -317,7 +317,7 @@ func TestEthInvalidChainID(t *testing.T) {
 	to := ethcmn.BytesToAddress(addr2.Bytes())
 	amt := big.NewInt(32)
 	gas := big.NewInt(20)
-	ethMsg := evmtypes.NewEthereumTxMsg(0, to, amt, 22000, gas, []byte("test"))
+	ethMsg := evmtypes.NewEthereumTxMsg(0, &to, amt, 22000, gas, []byte("test"))
 
 	tx := newTestEthTx(input.ctx, ethMsg, priv1)
 	ctx := input.ctx.WithChainID("bad-chain-id")

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -346,7 +346,7 @@ func (e *PublicEthAPI) Call(args CallArgs, blockNr rpc.BlockNumber, overrides *m
 	}
 
 	_, _, ret, err := types.DecodeReturnData(result.Data)
-	
+
 	return (hexutil.Bytes)(ret), err
 }
 
@@ -901,12 +901,12 @@ func (e *PublicEthAPI) GenerateFromArgs(args params.SendTxArgs) (msg *types.Ethe
 	}
 	if args.Gas == nil {
 		callArgs := CallArgs{
-			From: &args.From,
-			To: args.To,
-			Gas: args.Gas,
+			From:     &args.From,
+			To:       args.To,
+			Gas:      args.Gas,
 			GasPrice: args.GasPrice,
-			Value: args.Value,
-			Data: args.Data,
+			Value:    args.Value,
+			Data:     args.Data,
 		}
 		g, _ := e.EstimateGas(callArgs, rpc.BlockNumber(e.cliCtx.Height))
 		gasLimit = uint64(g)

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -864,7 +864,9 @@ func (e *PublicEthAPI) GenerateFromArgs(args params.SendTxArgs) (msg *types.Ethe
 	gasPrice := (*big.Int)(args.GasPrice)
 
 	if args.GasPrice == nil {
+
 		// Set default gas price
+		// TODO: Change to min gas price from context once available through server/daemon
 		gasPrice = big.NewInt(etypes.DefaultGasPrice)
 	}
 

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -864,9 +864,7 @@ func (e *PublicEthAPI) GenerateFromArgs(args params.SendTxArgs) (msg *types.Ethe
 	gasPrice := (*big.Int)(args.GasPrice)
 
 	if args.GasPrice == nil {
-
 		// Set default gas price
-		// TODO: Change to min gas price from context once available through server/daemon
 		gasPrice = big.NewInt(etypes.DefaultGasPrice)
 	}
 

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -11,6 +11,7 @@ import (
 	emintkeys "github.com/cosmos/ethermint/keys"
 	params "github.com/cosmos/ethermint/rpc/args"
 	emint "github.com/cosmos/ethermint/types"
+	etypes "github.com/cosmos/ethermint/types"
 	"github.com/cosmos/ethermint/utils"
 	"github.com/cosmos/ethermint/version"
 	"github.com/cosmos/ethermint/x/evm"
@@ -31,7 +32,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authutils "github.com/cosmos/cosmos-sdk/x/auth/client/utils"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	etypes "github.com/cosmos/ethermint/types"
 	"github.com/spf13/viper"
 )
 
@@ -899,7 +899,6 @@ func (e *PublicEthAPI) GenerateFromArgs(args params.SendTxArgs) (msg *types.Ethe
 			return nil, fmt.Errorf("contract creation without any data provided")
 		}
 	}
-
 	if args.Gas == nil {
 		callArgs := CallArgs{
 			From: &args.From,
@@ -915,5 +914,5 @@ func (e *PublicEthAPI) GenerateFromArgs(args params.SendTxArgs) (msg *types.Ethe
 		gasLimit = (uint64)(*args.Gas)
 	}
 
-	return types.NewEthereumTxMsg(nonce, *args.To, amount, gasLimit, gasPrice, input), nil
+	return types.NewEthereumTxMsg(nonce, args.To, amount, gasLimit, gasPrice, input), nil
 }

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -9,7 +9,7 @@ import (
 
 	emintcrypto "github.com/cosmos/ethermint/crypto"
 	emintkeys "github.com/cosmos/ethermint/keys"
-	"github.com/cosmos/ethermint/rpc/args"
+	params "github.com/cosmos/ethermint/rpc/args"
 	emint "github.com/cosmos/ethermint/types"
 	"github.com/cosmos/ethermint/utils"
 	"github.com/cosmos/ethermint/version"
@@ -31,7 +31,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authutils "github.com/cosmos/cosmos-sdk/x/auth/client/utils"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-
+	etypes "github.com/cosmos/ethermint/types"
 	"github.com/spf13/viper"
 )
 
@@ -248,7 +248,7 @@ func (e *PublicEthAPI) Sign(address common.Address, data hexutil.Bytes) (hexutil
 }
 
 // SendTransaction sends an Ethereum transaction.
-func (e *PublicEthAPI) SendTransaction(args args.SendTxArgs) (common.Hash, error) {
+func (e *PublicEthAPI) SendTransaction(args params.SendTxArgs) (common.Hash, error) {
 	// TODO: Change this functionality to find an unlocked account by address
 	if e.key == nil || !bytes.Equal(e.key.PubKey().Address().Bytes(), args.From.Bytes()) {
 		return common.Hash{}, keystore.ErrLocked
@@ -261,7 +261,7 @@ func (e *PublicEthAPI) SendTransaction(args args.SendTxArgs) (common.Hash, error
 	}
 
 	// Assemble transaction from fields
-	tx, err := types.GenerateFromArgs(args, e.cliCtx)
+	tx, err := e.GenerateFromArgs(args)
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -851,4 +851,69 @@ func (e *PublicEthAPI) getGasLimit() (int64, error) {
 	gasLimit := genesis.Genesis.ConsensusParams.Block.MaxGas
 	e.gasLimit = &gasLimit
 	return gasLimit, nil
+}
+
+// GenerateFromArgs populates tx message with args (used in RPC API)
+func (e *PublicEthAPI) GenerateFromArgs(args params.SendTxArgs) (msg *types.EthereumTxMsg, err error) {
+	var nonce uint64
+
+	var gasLimit uint64
+
+	amount := (*big.Int)(args.Value)
+
+	gasPrice := (*big.Int)(args.GasPrice)
+
+	if args.GasPrice == nil {
+
+		// Set default gas price
+		// TODO: Change to min gas price from context once available through server/daemon
+		gasPrice = big.NewInt(etypes.DefaultGasPrice)
+	}
+
+	if args.Nonce == nil {
+		// Get nonce (sequence) from account
+		from := sdk.AccAddress(args.From.Bytes())
+		_, nonce, err = authtypes.NewAccountRetriever(e.cliCtx).GetAccountNumberSequence(from)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		nonce = (uint64)(*args.Nonce)
+	}
+
+	if args.Data != nil && args.Input != nil && !bytes.Equal(*args.Data, *args.Input) {
+		return nil, fmt.Errorf(`both "data" and "input" are set and not equal. Please use "input" to pass transaction call data`)
+	}
+
+	// Sets input to either Input or Data, if both are set and not equal error above returns
+	var input []byte
+	if args.Input != nil {
+		input = *args.Input
+	} else if args.Data != nil {
+		input = *args.Data
+	}
+
+	if args.To == nil {
+		// Contract creation
+		if len(input) == 0 {
+			return nil, fmt.Errorf("contract creation without any data provided")
+		}
+	}
+
+	if args.Gas == nil {
+		callArgs := CallArgs{
+			From: &args.From,
+			To: args.To,
+			Gas: args.Gas,
+			GasPrice: args.GasPrice,
+			Value: args.Value,
+			Data: args.Data,
+		}
+		g, _ := e.EstimateGas(callArgs, rpc.BlockNumber(e.cliCtx.Height))
+		gasLimit = uint64(g)
+	} else {
+		gasLimit = (uint64)(*args.Gas)
+	}
+
+	return types.NewEthereumTxMsg(nonce, *args.To, amount, gasLimit, gasPrice, input), nil
 }

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -71,9 +71,9 @@ func GetCmdGenTx(cdc *codec.Codec) *cobra.Command {
 			}
 
 			payload := args[4]
-
+			addr := ethcmn.HexToAddress(args[0])
 			// TODO: Remove explicit photon check and check variables
-			msg := types.NewEthereumTxMsg(0, ethcmn.HexToAddress(args[0]), big.NewInt(coins.AmountOf(emintTypes.DenomDefault).Int64()), gasLimit, new(big.Int).SetUint64(gasPrice), []byte(payload))
+			msg := types.NewEthereumTxMsg(0, &addr, big.NewInt(coins.AmountOf(emintTypes.DenomDefault).Int64()), gasLimit, new(big.Int).SetUint64(gasPrice), []byte(payload))
 			err = msg.ValidateBasic()
 			if err != nil {
 				return err
@@ -125,7 +125,8 @@ func GetCmdGenETHTx(cdc *codec.Codec) *cobra.Command {
 
 			var tx *types.EthereumTxMsg
 			if len(args) == 5 {
-				tx = types.NewEthereumTxMsg(txBldr.Sequence(), ethcmn.HexToAddress(args[4]), big.NewInt(coins.AmountOf(emintTypes.DenomDefault).Int64()), gasLimit, new(big.Int).SetUint64(gasPrice), []byte(payload))
+				addr := ethcmn.HexToAddress(args[4])
+				tx = types.NewEthereumTxMsg(txBldr.Sequence(), &addr, big.NewInt(coins.AmountOf(emintTypes.DenomDefault).Int64()), gasLimit, new(big.Int).SetUint64(gasPrice), []byte(payload))
 			} else {
 				tx = types.NewEthereumTxMsgContract(txBldr.Sequence(), big.NewInt(coins.AmountOf(emintTypes.DenomDefault).Int64()), gasLimit, new(big.Int).SetUint64(gasPrice), []byte(payload))
 			}

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"bytes"
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
@@ -11,11 +10,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/cosmos/ethermint/rpc/args"
 	"github.com/cosmos/ethermint/types"
 
-	"github.com/cosmos/cosmos-sdk/client/context"
 	ethcmn "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
@@ -376,61 +372,4 @@ func recoverEthSig(R, S, Vb *big.Int, sigHash ethcmn.Hash) (ethcmn.Address, erro
 	copy(addr[:], ethcrypto.Keccak256(pub[1:])[12:])
 
 	return addr, nil
-}
-
-// GenerateFromArgs populates tx message with args (used in RPC API)
-func GenerateFromArgs(args args.SendTxArgs, ctx context.CLIContext) (msg *EthereumTxMsg, err error) {
-	var nonce uint64
-
-	var gasLimit uint64
-
-	amount := (*big.Int)(args.Value)
-
-	gasPrice := (*big.Int)(args.GasPrice)
-
-	if args.GasPrice == nil {
-		// Set default gas price
-		// TODO: Change to min gas price from context once available through server/daemon
-		gasPrice = big.NewInt(types.DefaultGasPrice)
-	}
-
-	if args.Nonce == nil {
-		// Get nonce (sequence) from account
-		from := sdk.AccAddress(args.From.Bytes())
-		_, nonce, err = authtypes.NewAccountRetriever(ctx).GetAccountNumberSequence(from)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		nonce = (uint64)(*args.Nonce)
-	}
-
-	if args.Data != nil && args.Input != nil && !bytes.Equal(*args.Data, *args.Input) {
-		return nil, fmt.Errorf(`both "data" and "input" are set and not equal. Please use "input" to pass transaction call data`)
-	}
-
-	// Sets input to either Input or Data, if both are set and not equal error above returns
-	var input []byte
-	if args.Input != nil {
-		input = *args.Input
-	} else if args.Data != nil {
-		input = *args.Data
-	}
-
-	if args.To == nil {
-		// Contract creation
-		if len(input) == 0 {
-			return nil, fmt.Errorf("contract creation without any data provided")
-		}
-	}
-
-	if args.Gas == nil {
-		// Estimate the gas usage if necessary.
-		// TODO: Set gas based on estimate when simulating txs are setup
-		gasLimit = 60000
-	} else {
-		gasLimit = (uint64)(*args.Gas)
-	}
-
-	return newEthereumTxMsg(nonce, args.To, amount, gasLimit, gasPrice, input), nil
 }

--- a/x/evm/types/msg.go
+++ b/x/evm/types/msg.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"math/big"
 	"sync/atomic"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/ethermint/types"
@@ -71,11 +70,11 @@ type (
 
 // NewEthereumTxMsg returns a reference to a new Ethereum transaction message.
 func NewEthereumTxMsg(
-	nonce uint64, to ethcmn.Address, amount *big.Int,
+	nonce uint64, to *ethcmn.Address, amount *big.Int,
 	gasLimit uint64, gasPrice *big.Int, payload []byte,
 ) *EthereumTxMsg {
 
-	return newEthereumTxMsg(nonce, &to, amount, gasLimit, gasPrice, payload)
+	return newEthereumTxMsg(nonce, to, amount, gasLimit, gasPrice, payload)
 }
 
 // NewEthereumTxMsgContract returns a reference to a new Ethereum transaction

--- a/x/evm/types/msg_test.go
+++ b/x/evm/types/msg_test.go
@@ -19,7 +19,7 @@ import (
 func TestMsgEthereumTx(t *testing.T) {
 	addr := GenerateEthAddress()
 
-	msg1 := NewEthereumTxMsg(0, addr, nil, 100000, nil, []byte("test"))
+	msg1 := NewEthereumTxMsg(0, &addr, nil, 100000, nil, []byte("test"))
 	require.NotNil(t, msg1)
 	require.Equal(t, *msg1.Data.Recipient, addr)
 
@@ -27,7 +27,7 @@ func TestMsgEthereumTx(t *testing.T) {
 	require.NotNil(t, msg2)
 	require.Nil(t, msg2.Data.Recipient)
 
-	msg3 := NewEthereumTxMsg(0, addr, nil, 100000, nil, []byte("test"))
+	msg3 := NewEthereumTxMsg(0, &addr, nil, 100000, nil, []byte("test"))
 	require.Equal(t, msg3.Route(), RouteEthereumTxMsg)
 	require.Equal(t, msg3.Type(), TypeEthereumTxMsg)
 	require.Panics(t, func() { msg3.GetSigners() })
@@ -50,7 +50,7 @@ func TestMsgEthereumTxValidation(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		msg := NewEthereumTxMsg(tc.nonce, tc.to, tc.amount, tc.gasLimit, tc.gasPrice, tc.payload)
+		msg := NewEthereumTxMsg(tc.nonce, &tc.to, tc.amount, tc.gasLimit, tc.gasPrice, tc.payload)
 
 		if tc.expectPass {
 			require.Nil(t, msg.ValidateBasic(), "test: %v", i)
@@ -64,14 +64,14 @@ func TestMsgEthereumTxRLPSignBytes(t *testing.T) {
 	addr := ethcmn.BytesToAddress([]byte("test_address"))
 	chainID := big.NewInt(3)
 
-	msg := NewEthereumTxMsg(0, addr, nil, 100000, nil, []byte("test"))
+	msg := NewEthereumTxMsg(0, &addr, nil, 100000, nil, []byte("test"))
 	hash := msg.RLPSignBytes(chainID)
 	require.Equal(t, "5BD30E35AD27449390B14C91E6BCFDCAADF8FE44EF33680E3BC200FC0DC083C7", fmt.Sprintf("%X", hash))
 }
 
 func TestMsgEthereumTxRLPEncode(t *testing.T) {
 	addr := ethcmn.BytesToAddress([]byte("test_address"))
-	msg := NewEthereumTxMsg(0, addr, nil, 100000, nil, []byte("test"))
+	msg := NewEthereumTxMsg(0, &addr, nil, 100000, nil, []byte("test"))
 
 	raw, err := rlp.EncodeToBytes(msg)
 	require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestMsgEthereumTxRLPDecode(t *testing.T) {
 
 	raw := ethcmn.FromHex("E48080830186A0940000000000000000746573745F61646472657373808474657374808080")
 	addr := ethcmn.BytesToAddress([]byte("test_address"))
-	expectedMsg := NewEthereumTxMsg(0, addr, nil, 100000, nil, []byte("test"))
+	expectedMsg := NewEthereumTxMsg(0, &addr, nil, 100000, nil, []byte("test"))
 
 	err := rlp.Decode(bytes.NewReader(raw), &msg)
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestMsgEthereumTxRLPDecode(t *testing.T) {
 
 func TestMsgEthereumTxHash(t *testing.T) {
 	addr := ethcmn.BytesToAddress([]byte("test_address"))
-	msg := NewEthereumTxMsg(0, addr, nil, 100000, nil, []byte("test"))
+	msg := NewEthereumTxMsg(0, &addr, nil, 100000, nil, []byte("test"))
 
 	hash := msg.Hash()
 	require.Equal(t, "E2AA2E68E7586AE9700F1D3D643330866B6AC2B6CA4C804F7C85ECB11D0B0B29", fmt.Sprintf("%X", hash))
@@ -107,7 +107,7 @@ func TestMsgEthereumTxSig(t *testing.T) {
 	addr2 := ethcmn.BytesToAddress(priv2.PubKey().Address().Bytes())
 
 	// require valid signature passes validation
-	msg := NewEthereumTxMsg(0, addr1, nil, 100000, nil, []byte("test"))
+	msg := NewEthereumTxMsg(0, &addr1, nil, 100000, nil, []byte("test"))
 	msg.Sign(chainID, priv1.ToECDSA())
 
 	signer, err := msg.VerifySig(chainID)
@@ -116,7 +116,7 @@ func TestMsgEthereumTxSig(t *testing.T) {
 	require.NotEqual(t, addr2, signer)
 
 	// require invalid chain ID fail validation
-	msg = NewEthereumTxMsg(0, addr1, nil, 100000, nil, []byte("test"))
+	msg = NewEthereumTxMsg(0, &addr1, nil, 100000, nil, []byte("test"))
 	msg.Sign(chainID, priv1.ToECDSA())
 
 	signer, err = msg.VerifySig(big.NewInt(4))
@@ -126,7 +126,7 @@ func TestMsgEthereumTxSig(t *testing.T) {
 
 func TestMsgEthereumTxAmino(t *testing.T) {
 	addr := GenerateEthAddress()
-	msg := NewEthereumTxMsg(5, addr, big.NewInt(1), 100000, big.NewInt(3), []byte("test"))
+	msg := NewEthereumTxMsg(5, &addr, big.NewInt(1), 100000, big.NewInt(3), []byte("test"))
 
 	msg.Data.V = big.NewInt(1)
 	msg.Data.R = big.NewInt(2)


### PR DESCRIPTION
Draft PR for `eth_estimateGas`:

Changes made:
- Refactored `doCall` implemented in #127 to be used for both `eth_Call` and `eth_estimateGas`
- Above refactor is reflected in `Call` function as well
- Implemented `eth_estimateGas` which returns the `GasUsed` field from the simulated transaction call in `doCall`

To test:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_estimateGas","params":[{"from":"0x'$(echo -n $(emintcli emintkeys show dustineth -w))'","to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","gas":"0x76c0","gasPrice":"0x12","value":"0x20","data":"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}, "latest"],"id":1}' -H "Content-Type: application/json" http://localhost:8545/rpc
```
Expected Response:
```
{
  "id":1,
  "jsonrpc": "2.0",
  "result": "0x6bd3" // 27603
}
```
 