### PR TITLE
Fixes gas limit for simulated transaction

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -257,7 +257,7 @@ func ethAnteHandler(
 	// Set gas meter after ante handler to ignore gaskv costs
 	newCtx = auth.SetGasMeter(sim, ctx, ethTxMsg.Data.GasLimit)
 
-	gas, _ := ethcore.IntrinsicGas(ethTxMsg.Data.Payload, ethTxMsg.To() == nil, false)
+	gas, _ := ethcore.IntrinsicGas(ethTxMsg.Data.Payload, ethTxMsg.To() == nil, true)
 	newCtx.GasMeter().ConsumeGas(gas, "eth intrinsic gas")
 
 	return newCtx, sdk.Result{}, false
@@ -313,7 +313,7 @@ func validateSignature(ctx sdk.Context, ethTxMsg *evmtypes.EthereumTxMsg) (sdk.A
 // constant value of 21000 plus any cost inccured by additional bytes of data
 // supplied with the transaction.
 func validateIntrinsicGas(ethTxMsg *evmtypes.EthereumTxMsg) sdk.Result {
-	gas, err := ethcore.IntrinsicGas(ethTxMsg.Data.Payload, ethTxMsg.To() == nil, false)
+	gas, err := ethcore.IntrinsicGas(ethTxMsg.Data.Payload, ethTxMsg.To() == nil, true)
 	if err != nil {
 		return sdk.ErrInternal(fmt.Sprintf("failed to compute intrinsic gas cost: %s", err)).Result()
 	}

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -73,7 +73,7 @@ func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk
 	keeper.csdb.Prepare(ethHash, common.Hash{}, keeper.txCount.get())
 	keeper.txCount.increment()
 
-	res, bloom := st.TransitionCSDB(ctx)
+	bloom, res := st.TransitionCSDB(ctx)
 	keeper.bloom.Or(keeper.bloom, bloom)
 	return res
 }
@@ -110,6 +110,6 @@ func handleEmintMsg(ctx sdk.Context, keeper Keeper, msg types.EmintMsg) sdk.Resu
 	keeper.csdb.Prepare(common.Hash{}, common.Hash{}, keeper.txCount.get()) // Cannot provide tx hash
 	keeper.txCount.increment()
 
-	res, _ := st.TransitionCSDB(ctx)
+	_, res := st.TransitionCSDB(ctx)
 	return res
 }

--- a/x/evm/types/state_transition.go
+++ b/x/evm/types/state_transition.go
@@ -44,9 +44,9 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (*big.Int, sdk.Result)
 	// This gas limit the the transaction gas limit with intrinsic gas subtracted
 	gasLimit := st.GasLimit - ctx.GasMeter().GasConsumed()
 
-	// This check is because stdTxs use gas differently, but for eth_call it needs to be the same
-	// as an Ethereum transaction sent through the web3 API
 	if st.Simulate {
+		// gasLimit is set here because stdTxs incur gaskv charges in the ante handler, but for eth_call
+		// the cost needs to be the same as an Ethereum transaction sent through the web3 API
 		gasLimit = st.GasLimit - cost
 	}
 

--- a/x/evm/types/state_transition.go
+++ b/x/evm/types/state_transition.go
@@ -29,15 +29,26 @@ type StateTransition struct {
 }
 
 // TransitionCSDB performs an evm state transition from a transaction
-func (st StateTransition) TransitionCSDB(ctx sdk.Context) (sdk.Result, *big.Int) {
+func (st StateTransition) TransitionCSDB(ctx sdk.Context) (*big.Int, sdk.Result) {
 	contractCreation := st.Recipient == nil
 
 	if res := st.checkNonce(); !res.IsOK() {
-		return res, nil
+		return nil, res
+	}
+
+	cost, err := core.IntrinsicGas(st.Payload, st.Recipient == nil, true)
+	if err != nil {
+		return nil, sdk.ErrOutOfGas("invalid intrinsic gas for transaction").Result()
 	}
 
 	// This gas limit the the transaction gas limit with intrinsic gas subtracted
-	gasLimit := ctx.GasMeter().Limit()
+	gasLimit := st.GasLimit - ctx.GasMeter().GasConsumed()
+
+	// This check is because stdTxs use gas differently, but for eth_call it needs to be the same
+	// as an Ethereum transaction sent through the web3 API
+	if st.Simulate {
+		gasLimit = st.GasLimit - cost
+	}
 
 	// Create context for evm
 	context := vm.Context{
@@ -92,7 +103,7 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (sdk.Result, *big.Int)
 	if vmerr != nil {
 		res := emint.ErrVMExecution(vmerr.Error()).Result()
 		res.Data = returnData
-		return res, nil
+		return nil, res
 	}
 
 	// TODO: Refund unused gas here, if intended in future
@@ -103,7 +114,7 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (sdk.Result, *big.Int)
 	// Out of gas check does not need to be done here since it is done within the EVM execution
 	ctx.GasMeter().ConsumeGas(gasLimit-leftOverGas, "EVM execution consumption")
 
-	return sdk.Result{Data: returnData, GasUsed: st.GasLimit - leftOverGas}, bloomInt
+	return bloomInt, sdk.Result{Data: returnData, GasUsed: st.GasLimit - leftOverGas}
 }
 
 func (st *StateTransition) checkNonce() sdk.Result {


### PR DESCRIPTION
- Fixes eth_call interaction from using 0 gas limit by default

Since the gas meter limit cannot be relied on for gas limits for the evm since the ante handlers set the gas meters differently, uses message gas limit value.