### PR TITLE
Fix EVM out of gas handling

### DIFF
--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -74,7 +74,9 @@ func handleETHTxMsg(ctx sdk.Context, keeper Keeper, msg types.EthereumTxMsg) sdk
 	keeper.txCount.increment()
 
 	bloom, res := st.TransitionCSDB(ctx)
-	keeper.bloom.Or(keeper.bloom, bloom)
+	if res.IsOK() {
+		keeper.bloom.Or(keeper.bloom, bloom)
+	}
 	return res
 }
 


### PR DESCRIPTION
- Consumed gas correctly on out of gas in EVM for proper gas used in receipts
- Fixed check for bloom filter to handle edge case for better error reporting in Cosmos tx logs

Just noticed some improper error handling when running out of gas in EVM