### PR TITLE
Fix eth_estimateGas and simulated txs 

### DIFF
--- a/x/evm/types/statedb.go
+++ b/x/evm/types/statedb.go
@@ -571,7 +571,7 @@ func (csdb *CommitStateDB) CreateAccount(addr ethcmn.Address) {
 // Copy creates a deep, independent copy of the state.
 //
 // NOTE: Snapshots of the copied state cannot be applied to the copy.
-func (csdb *CommitStateDB) Copy() ethvm.StateDB {
+func (csdb *CommitStateDB) Copy() *CommitStateDB {
 	csdb.lock.Lock()
 	defer csdb.lock.Unlock()
 


### PR DESCRIPTION
- Fixes function signature for Estimate gas endpoint (doesn't take blocknumber as a parameter which errored dev tooling usage) #128 
- Added a buffer for the gas cost of the estimate (if exactly the gas used is set as limit, the tx will error with out of gas)
- Refactored the evm state transition simulation to use a copy of the StateDB instead of performing the transactions and reverting to a snapshot (just for safety since in edge cases there will be inconsistencies)
- In simulated transactions, makes sure the intrinsic gas consumed in the AnteHandler is at least the EVM intrinsic gas, to fix the gas estimate for Ethereum transactions (The discrepancy is mainly for create transactions)

These changes are sufficient for Remix support (estimate gas was broken but could still work before)