### PR TITLE
Fix block gas limit return for dev tooling

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -861,6 +861,12 @@ func (e *PublicEthAPI) getGasLimit() (int64, error) {
 
 	// Save value to gasLimit cached value
 	gasLimit := genesis.Genesis.ConsensusParams.Block.MaxGas
+	if gasLimit == -1 {
+		// Sets gas limit to max uint32 to not error with javascript dev tooling
+		// This -1 value indicating no block gas limit is set to max uint64 with geth hexutils
+		// which errors certain javascript dev tooling which only supports up to 53 bits
+		gasLimit = int64(^uint32(0))
+	}
 	e.gasLimit = &gasLimit
 	return gasLimit, nil
 }

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -541,7 +541,7 @@ func formatBlock(
 		"logsBloom":        bloom,
 		"transactionsRoot": hexutil.Bytes(header.DataHash),
 		"stateRoot":        hexutil.Bytes(header.AppHash),
-		"miner":            hexutil.Bytes(header.ValidatorsHash),
+		"miner":            common.Address{},
 		"difficulty":       nil,
 		"totalDifficulty":  nil,
 		"extraData":        nil,


### PR DESCRIPTION
- When there is no block gas limit in Tendermint, the gas limit value is -1. When formatted with geth's hexutils this becomes the max uint64 value. This changes the returned value to max uint32 (4_294_967_295) for dev tooling support (specifically Truffle5) which is larger than it should ever be and this value does not affect anything other than the value returned through the web3 API and should never be actually checked
- Fixes #149 

Edit: also changes miner address to just be blank since validators hash is different length and is verified by at least truffle5