### PR TITLE
Coin balance fix

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -139,10 +139,11 @@ func ethAnteHandler(
 		// Cost calculates the fees paid to validators based on gas limit and price
 		cost := new(big.Int).Mul(ethTxMsg.Data.Price, new(big.Int).SetUint64(ethTxMsg.Data.GasLimit))
 
-		err = auth.DeductFees(sk, ctx, senderAcc, sdk.Coins{
+		feeAmt := sdk.Coins{
 			sdk.NewCoin(emint.DenomDefault, sdk.NewIntFromBigInt(cost)),
-		})
+		}
 
+		err = auth.DeductFees(sk, ctx, senderAcc, feeAmt)
 		if err != nil {
 			return ctx, err
 		}

--- a/app/ethermint.go
+++ b/app/ethermint.go
@@ -197,9 +197,9 @@ func NewEthermintApp(
 	// During begin block slashing happens after distr.BeginBlocker so that
 	// there is nothing left over in the validator fee pool, so as to keep the
 	// CanWithdrawInvariant invariant.
-	app.mm.SetOrderBeginBlockers(mint.ModuleName, distr.ModuleName, slashing.ModuleName, evmtypes.ModuleName)
+	app.mm.SetOrderBeginBlockers(evmtypes.ModuleName, mint.ModuleName, distr.ModuleName, slashing.ModuleName)
 
-	app.mm.SetOrderEndBlockers(crisis.ModuleName, gov.ModuleName, staking.ModuleName, evmtypes.ModuleName)
+	app.mm.SetOrderEndBlockers(evmtypes.ModuleName, crisis.ModuleName, gov.ModuleName, staking.ModuleName)
 
 	// NOTE: The genutils module must occur after staking so that pools are
 	// properly initialized with tokens from genesis accounts.

--- a/types/account.go
+++ b/types/account.go
@@ -49,7 +49,6 @@ func (acc Account) Balance() sdk.Int {
 
 // SetBalance sets an account's balance of photons
 func (acc Account) SetBalance(amt sdk.Int) {
-	//nolint:gosec,errcheck
 	coins := acc.GetCoins()
 	diff := amt.Sub(coins.AmountOf(DenomDefault))
 	if diff.IsZero() {
@@ -61,7 +60,9 @@ func (acc Account) SetBalance(amt sdk.Int) {
 		// Decrease coins to amount
 		coins = coins.Sub(sdk.Coins{sdk.NewCoin(DenomDefault, diff.Neg())})
 	}
-	acc.SetCoins(coins)
+	if err := acc.SetCoins(coins); err != nil {
+		panic(fmt.Sprintf("Could not set coins for address %s", acc.GetAddress()))
+	}
 }
 
 // ----------------------------------------------------------------------------

--- a/types/account.go
+++ b/types/account.go
@@ -47,10 +47,21 @@ func (acc Account) Balance() sdk.Int {
 	return acc.GetCoins().AmountOf(DenomDefault)
 }
 
-// SetBalance sets an account's balance.
+// SetBalance sets an account's balance of photons
 func (acc Account) SetBalance(amt sdk.Int) {
 	//nolint:gosec,errcheck
-	acc.SetCoins(sdk.Coins{sdk.NewCoin(DenomDefault, amt)})
+	coins := acc.GetCoins()
+	diff := amt.Sub(coins.AmountOf(DenomDefault))
+	if diff.IsZero() {
+		return
+	} else if diff.IsPositive() {
+		// Increase coins to amount
+		coins = coins.Add(sdk.Coins{sdk.NewCoin(DenomDefault, diff)})
+	} else {
+		// Decrease coins to amount
+		coins = coins.Sub(sdk.Coins{sdk.NewCoin(DenomDefault, diff.Neg())})
+	}
+	acc.SetCoins(coins)
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
- Existing type setup had assumed that each account would only have photons allocated (assuming because it was assumed that Ethermint would be a single denom chain).
- Changed order for end blocker to set account balances from transactions are updated before any other module using the account balances.

Note:
There still is an issue with coin balances not being updated correctly, most likely due to the order of when the account balances get updated in Ethermint (end of block instead of during the message handler) but these changes will come incrementally.