### PR TITLE
Finish and clean up module queries and txs

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -48,7 +48,9 @@ func NewAnteHandler(ak auth.AccountKeeper, sk types.SupplyKeeper) sdk.AnteHandle
 				ante.NewDeductFeeDecorator(ak, sk),
 				ante.NewSigGasConsumeDecorator(ak, consumeSigGas),
 				ante.NewSigVerificationDecorator(ak),
-				ante.NewIncrementSequenceDecorator(ak), // innermost AnteDecorator
+				// * Increment sequence decorator is disabled temporarily, since increment occurs in
+				// * state transition
+				// ante.NewIncrementSequenceDecorator(ak), // innermost AnteDecorator
 			)
 
 			return stdAnte(ctx, tx, sim)

--- a/client/genaccounts/main.go
+++ b/client/genaccounts/main.go
@@ -1,4 +1,4 @@
-package main
+package genaccounts
 
 import (
 	"errors"

--- a/cmd/emintcli/main.go
+++ b/cmd/emintcli/main.go
@@ -5,6 +5,7 @@ import (
 	"path"
 
 	emintapp "github.com/cosmos/ethermint/app"
+	emintcrypto "github.com/cosmos/ethermint/crypto"
 	"github.com/cosmos/ethermint/rpc"
 
 	"github.com/tendermint/go-amino"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	tmamino "github.com/tendermint/tendermint/crypto/encoding/amino"
 	"github.com/tendermint/tendermint/libs/cli"
 )
 
@@ -27,6 +29,9 @@ func main() {
 	cobra.EnableCommandSorting = false
 
 	cdc := emintapp.MakeCodec()
+
+	tmamino.RegisterKeyType(emintcrypto.PubKeySecp256k1{}, emintcrypto.PubKeyAminoName)
+	tmamino.RegisterKeyType(emintcrypto.PrivKeySecp256k1{}, emintcrypto.PrivKeyAminoName)
 
 	cryptokeys.CryptoCdc = cdc
 	clientkeys.KeysCdc = cdc

--- a/cmd/emintd/main.go
+++ b/cmd/emintd/main.go
@@ -24,8 +24,10 @@ import (
 
 	"github.com/cosmos/ethermint/app"
 	emintapp "github.com/cosmos/ethermint/app"
+	emintcrypto "github.com/cosmos/ethermint/crypto"
 
 	abci "github.com/tendermint/tendermint/abci/types"
+	tmamino "github.com/tendermint/tendermint/crypto/encoding/amino"
 	"github.com/tendermint/tendermint/libs/cli"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	tmtypes "github.com/tendermint/tendermint/types"
@@ -36,6 +38,9 @@ func main() {
 	cobra.EnableCommandSorting = false
 
 	cdc := emintapp.MakeCodec()
+
+	tmamino.RegisterKeyType(emintcrypto.PubKeySecp256k1{}, emintcrypto.PubKeyAminoName)
+	tmamino.RegisterKeyType(emintcrypto.PrivKeySecp256k1{}, emintcrypto.PrivKeyAminoName)
 
 	cryptokeys.CryptoCdc = cdc
 	genutil.ModuleCdc = cdc

--- a/cmd/emintd/main.go
+++ b/cmd/emintd/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cosmos/ethermint/app"
 	emintapp "github.com/cosmos/ethermint/app"
+	"github.com/cosmos/ethermint/client/genaccounts"
 	emintcrypto "github.com/cosmos/ethermint/crypto"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -70,7 +71,7 @@ func main() {
 		genutilcli.ValidateGenesisCmd(ctx, cdc, emintapp.ModuleBasics),
 
 		// AddGenesisAccountCmd allows users to add accounts to the genesis file
-		AddGenesisAccountCmd(ctx, cdc, app.DefaultNodeHome, app.DefaultCLIHome),
+		genaccounts.AddGenesisAccountCmd(ctx, cdc, app.DefaultNodeHome, app.DefaultCLIHome),
 	)
 
 	// Tendermint node base commands

--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -10,12 +10,9 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	tmcrypto "github.com/tendermint/tendermint/crypto"
-	tmamino "github.com/tendermint/tendermint/crypto/encoding/amino"
 )
 
 func init() {
-	tmamino.RegisterKeyType(PubKeySecp256k1{}, PubKeyAminoName)
-	tmamino.RegisterKeyType(PrivKeySecp256k1{}, PrivKeyAminoName)
 	authtypes.RegisterAccountTypeCodec(PubKeySecp256k1{}, PubKeyAminoName)
 	authtypes.RegisterAccountTypeCodec(PrivKeySecp256k1{}, PrivKeyAminoName)
 }

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -268,7 +268,7 @@ func (e *PublicEthAPI) SendTransaction(args params.SendTxArgs) (common.Hash, err
 	}
 
 	// Assemble transaction from fields
-	tx, err := e.GenerateFromArgs(args)
+	tx, err := e.generateFromArgs(args)
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -871,8 +871,8 @@ func (e *PublicEthAPI) getGasLimit() (int64, error) {
 	return gasLimit, nil
 }
 
-// GenerateFromArgs populates tx message with args (used in RPC API)
-func (e *PublicEthAPI) GenerateFromArgs(args params.SendTxArgs) (msg *types.EthereumTxMsg, err error) {
+// generateFromArgs populates tx message with args (used in RPC API)
+func (e *PublicEthAPI) generateFromArgs(args params.SendTxArgs) (msg *types.EthereumTxMsg, err error) {
 	var nonce uint64
 
 	var gasLimit uint64

--- a/x/evm/client/cli/query.go
+++ b/x/evm/client/cli/query.go
@@ -2,17 +2,13 @@ package cli
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/ethermint/x/evm/types"
 )
@@ -87,27 +83,4 @@ func GetCmdGetCode(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			return cliCtx.PrintOutput(out)
 		},
 	}
-}
-
-func accountToHex(addr string) (string, error) {
-	if strings.HasPrefix("cosmos", addr) {
-		// Check to see if address is Cosmos bech32 formatted
-		toAddr, err := sdk.AccAddressFromBech32(addr)
-		if err != nil {
-			return "", errors.Wrap(err, "must provide a valid Bech32 address")
-		}
-		ethAddr := common.BytesToAddress(toAddr.Bytes())
-		return ethAddr.Hex(), nil
-	}
-
-	if !strings.HasPrefix(addr, "0x") {
-		addr = "0x" + addr
-	}
-
-	valid := common.IsHexAddress(addr)
-	if !valid {
-		return "", fmt.Errorf("%s is not a valid Ethereum or Cosmos address", addr)
-	}
-
-	return addr, nil
 }

--- a/x/evm/client/cli/query.go
+++ b/x/evm/client/cli/query.go
@@ -42,7 +42,8 @@ func GetCmdGetStorageAt(queryRoute string, cdc *codec.Codec) *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "could not parse account address")
 			}
-			key := args[1]
+
+			key := formatKeyToHash(args[1])
 
 			res, _, err := cliCtx.Query(
 				fmt.Sprintf("custom/%s/storage/%s/%s", queryRoute, account, key))

--- a/x/evm/client/cli/query.go
+++ b/x/evm/client/cli/query.go
@@ -2,12 +2,19 @@ package cli
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/cosmos/ethermint/x/evm/types"
-	"github.com/spf13/cobra"
 )
 
 // GetQueryCmd defines evm module queries through the cli
@@ -20,33 +27,10 @@ func GetQueryCmd(moduleName string, cdc *codec.Codec) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 	evmQueryCmd.AddCommand(client.GetCommands(
-		GetCmdGetBlockNumber(moduleName, cdc),
 		GetCmdGetStorageAt(moduleName, cdc),
 		GetCmdGetCode(moduleName, cdc),
-		GetCmdGetNonce(moduleName, cdc),
 	)...)
 	return evmQueryCmd
-}
-
-// GetCmdGetBlockNumber queries information about the current block number
-func GetCmdGetBlockNumber(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	return &cobra.Command{
-		Use:   "block-number",
-		Short: "Gets block number (block height)",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/blockNumber", queryRoute), nil)
-			if err != nil {
-				fmt.Printf("could not resolve: %s\n", err)
-				return nil
-			}
-
-			var out types.QueryResBlockNumber
-			cdc.MustUnmarshalJSON(res, &out)
-			return cliCtx.PrintOutput(out)
-		},
-	}
 }
 
 // GetCmdGetStorageAt queries a key in an accounts storage
@@ -58,14 +42,17 @@ func GetCmdGetStorageAt(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
-			// TODO: Validate args
-			account := args[0]
+			account, err := accountToHex(args[0])
+			if err != nil {
+				return errors.Wrap(err, "could not parse account address")
+			}
 			key := args[1]
 
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/storage/%s/%s", queryRoute, account, key), nil)
+			res, _, err := cliCtx.Query(
+				fmt.Sprintf("custom/%s/storage/%s/%s", queryRoute, account, key))
+
 			if err != nil {
-				fmt.Printf("could not resolve: %s\n", err)
-				return nil
+				return fmt.Errorf("could not resolve: %s", err)
 			}
 			var out types.QueryResStorage
 			cdc.MustUnmarshalJSON(res, &out)
@@ -83,14 +70,18 @@ func GetCmdGetCode(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
-			// TODO: Validate args
-			account := args[0]
-
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/code/%s", queryRoute, account), nil)
+			account, err := accountToHex(args[0])
 			if err != nil {
-				fmt.Printf("could not resolve: %s\n", err)
-				return nil
+				return errors.Wrap(err, "could not parse account address")
 			}
+
+			res, _, err := cliCtx.Query(
+				fmt.Sprintf("custom/%s/code/%s", queryRoute, account))
+
+			if err != nil {
+				return fmt.Errorf("could not resolve: %s", err)
+			}
+
 			var out types.QueryResCode
 			cdc.MustUnmarshalJSON(res, &out)
 			return cliCtx.PrintOutput(out)
@@ -98,26 +89,25 @@ func GetCmdGetCode(queryRoute string, cdc *codec.Codec) *cobra.Command {
 	}
 }
 
-// GetCmdGetCode queries the nonce field of a given address
-func GetCmdGetNonce(queryRoute string, cdc *codec.Codec) *cobra.Command {
-	return &cobra.Command{
-		Use:   "nonce [account]",
-		Short: "Gets nonce from an account",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliCtx := context.NewCLIContext().WithCodec(cdc)
-
-			// TODO: Validate args
-			account := args[0]
-
-			res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/nonce/%s", queryRoute, account), nil)
-			if err != nil {
-				fmt.Printf("could not resolve: %s\n", err)
-				return nil
-			}
-			var out types.QueryResNonce
-			cdc.MustUnmarshalJSON(res, &out)
-			return cliCtx.PrintOutput(out)
-		},
+func accountToHex(addr string) (string, error) {
+	if strings.HasPrefix("cosmos", addr) {
+		// Check to see if address is Cosmos bech32 formatted
+		toAddr, err := sdk.AccAddressFromBech32(addr)
+		if err != nil {
+			return "", errors.Wrap(err, "must provide a valid Bech32 address")
+		}
+		ethAddr := common.BytesToAddress(toAddr.Bytes())
+		return ethAddr.Hex(), nil
 	}
+
+	if !strings.HasPrefix(addr, "0x") {
+		addr = "0x" + addr
+	}
+
+	valid := common.IsHexAddress(addr)
+	if !valid {
+		return "", fmt.Errorf("%s is not a valid Ethereum or Cosmos address", addr)
+	}
+
+	return addr, nil
 }

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -18,10 +17,6 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	emint "github.com/cosmos/ethermint/types"
 	"github.com/cosmos/ethermint/x/evm/types"
-)
-
-const (
-	flagToAddress = "to-address"
 )
 
 // GetTxCmd defines the CLI commands regarding evm module transactions
@@ -41,40 +36,35 @@ func GetTxCmd(storeKey string, cdc *codec.Codec) *cobra.Command {
 	return evmTxCmd
 }
 
-// GetCmdGenTx generates an ethereum transaction wrapped in a Cosmos standard transaction
+// GetCmdGenTx generates an Emint transaction (excludes create operations)
 func GetCmdGenTx(cdc *codec.Codec) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "generate-tx [amount (in photons)] [<data>]",
-		Short: "generate eth tx wrapped in a Cosmos Standard tx",
-		Args:  cobra.RangeArgs(1, 2),
+	return &cobra.Command{
+		Use:   "send [to_address] [amount (in photons)] [<data>]",
+		Short: "send transaction to address (call operations included)",
+		Args:  cobra.RangeArgs(2, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 
 			// Ambiguously decode amount from any base
-			amount, err := strconv.ParseInt(args[0], 0, 64)
+			amount, err := strconv.ParseInt(args[1], 0, 64)
 			if err != nil {
 				return err
 			}
 
 			var data []byte
-			if len(args) > 1 {
-				payload := args[1]
+			if len(args) > 2 {
+				payload := args[2]
 				data, err = hexutil.Decode(payload)
 				if err != nil {
 					fmt.Println(err)
 				}
 			}
 
-			var toAddr *sdk.AccAddress
-			toFlag := viper.GetString(flagToAddress)
-			if toFlag != "" {
-				addr, err := sdk.AccAddressFromBech32(toFlag)
-				if err != nil {
-					return errors.Wrap(err, "must provide a valid Bech32 address for ")
-				}
-				toAddr = &addr
+			toAddr, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return errors.Wrap(err, "must provide a valid Bech32 address for to_address")
 			}
 
 			from := cliCtx.GetFromAddress()
@@ -84,7 +74,8 @@ func GetCmdGenTx(cdc *codec.Codec) *cobra.Command {
 				return errors.Wrap(err, "Could not retrieve account sequence")
 			}
 
-			msg := types.NewEmintMsg(seq, toAddr, sdk.NewInt(amount), txBldr.Gas(),
+			// TODO: Potentially allow overriding of gas price and gas limit
+			msg := types.NewEmintMsg(seq, &toAddr, sdk.NewInt(amount), txBldr.Gas(),
 				sdk.NewInt(emint.DefaultGasPrice), data, from)
 
 			err = msg.ValidateBasic()
@@ -95,9 +86,4 @@ func GetCmdGenTx(cdc *codec.Codec) *cobra.Command {
 			return utils.GenerateOrBroadcastMsgs(cliCtx, txBldr, []sdk.Msg{msg})
 		},
 	}
-
-	// Optional parameter flags
-	cmd.Flags().String(flagToAddress, "", "set to address for transaction")
-
-	return cmd
 }

--- a/x/evm/client/cli/tx.go
+++ b/x/evm/client/cli/tx.go
@@ -51,7 +51,7 @@ func GetCmdGenTx(cdc *codec.Codec) *cobra.Command {
 
 			txBldr := auth.NewTxBuilderFromCLI().WithTxEncoder(utils.GetTxEncoder(cdc))
 
-			toAddr, err := sdk.AccAddressFromBech32(args[0])
+			toAddr, err := cosmosAddressFromArg(args[0])
 			if err != nil {
 				return errors.Wrap(err, "must provide a valid Bech32 address for to_address")
 			}

--- a/x/evm/client/cli/utils.go
+++ b/x/evm/client/cli/utils.go
@@ -56,10 +56,8 @@ func cosmosAddressFromArg(addr string) (sdk.AccAddress, error) {
 		return toAddr, nil
 	}
 
-	if strings.HasPrefix(addr, "0x") {
-		// Strip 0x prefix if exists
-		addr = addr[2:]
-	}
+	// Strip 0x prefix if exists
+	addr = strings.TrimPrefix(addr, "0x")
 
 	return sdk.AccAddressFromHex(addr)
 }

--- a/x/evm/client/cli/utils.go
+++ b/x/evm/client/cli/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 func accountToHex(addr string) (string, error) {
-	if strings.HasPrefix(addr, "cosmos") {
+	if strings.HasPrefix(addr, sdk.Bech32PrefixAccAddr) {
 		// Check to see if address is Cosmos bech32 formatted
 		toAddr, err := sdk.AccAddressFromBech32(addr)
 		if err != nil {
@@ -34,4 +34,32 @@ func accountToHex(addr string) (string, error) {
 	ethAddr := common.HexToAddress(addr)
 
 	return ethAddr.Hex(), nil
+}
+
+func formatKeyToHash(key string) string {
+	if !strings.HasPrefix(key, "0x") {
+		key = "0x" + key
+	}
+
+	ethkey := common.HexToHash(key)
+
+	return ethkey.Hex()
+}
+
+func cosmosAddressFromArg(addr string) (sdk.AccAddress, error) {
+	if strings.HasPrefix(addr, sdk.Bech32PrefixAccAddr) {
+		// Check to see if address is Cosmos bech32 formatted
+		toAddr, err := sdk.AccAddressFromBech32(addr)
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid bech32 formatted address")
+		}
+		return toAddr, nil
+	}
+
+	if strings.HasPrefix(addr, "0x") {
+		// Strip 0x prefix if exists
+		addr = addr[2:]
+	}
+
+	return sdk.AccAddressFromHex(addr)
 }

--- a/x/evm/client/cli/utils.go
+++ b/x/evm/client/cli/utils.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func accountToHex(addr string) (string, error) {
+	if strings.HasPrefix(addr, "cosmos") {
+		// Check to see if address is Cosmos bech32 formatted
+		toAddr, err := sdk.AccAddressFromBech32(addr)
+		if err != nil {
+			return "", errors.Wrap(err, "must provide a valid Bech32 address")
+		}
+		ethAddr := common.BytesToAddress(toAddr.Bytes())
+		return ethAddr.Hex(), nil
+	}
+
+	if !strings.HasPrefix(addr, "0x") {
+		addr = "0x" + addr
+	}
+
+	valid := common.IsHexAddress(addr)
+	if !valid {
+		return "", fmt.Errorf("%s is not a valid Ethereum or Cosmos address", addr)
+	}
+
+	ethAddr := common.HexToAddress(addr)
+
+	return ethAddr.Hex(), nil
+}

--- a/x/evm/client/cli/utils_test.go
+++ b/x/evm/client/cli/utils_test.go
@@ -59,3 +59,24 @@ func TestCosmosToEthereumTypes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, hexString, ethDecoded)
 }
+
+func TestAddressToCosmosAddress(t *testing.T) {
+	baseAddr, err := sdk.AccAddressFromHex("6A98D72760f7bbA69d62Ed6F48278451251948E7")
+	require.NoError(t, err)
+
+	// Test cosmos string back to address
+	cosmosFormatted, err := cosmosAddressFromArg(baseAddr.String())
+	require.NoError(t, err)
+	require.Equal(t, baseAddr, cosmosFormatted)
+
+	// Test account address from Ethereum address
+	ethAddr := common.BytesToAddress(baseAddr.Bytes())
+	ethFormatted, err := cosmosAddressFromArg(ethAddr.Hex())
+	require.NoError(t, err)
+	require.Equal(t, baseAddr, ethFormatted)
+
+	// Test encoding without the 0x prefix
+	ethFormatted, err = cosmosAddressFromArg(ethAddr.Hex()[2:])
+	require.NoError(t, err)
+	require.Equal(t, baseAddr, ethFormatted)
+}

--- a/x/evm/client/cli/utils_test.go
+++ b/x/evm/client/cli/utils_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressFormats(t *testing.T) {
+	testCases := []struct {
+		name        string
+		addrString  string
+		expectedHex string
+		expectErr   bool
+	}{
+		{"Cosmos Address", "cosmos18wvvwfmq77a6d8tza4h5sfuy2yj3jj88yqg82a", "0x3B98c72760f7BBa69D62ED6f48278451251948e7", false},
+		{"hex without 0x", "3B98C72760F7BBA69D62ED6F48278451251948E7", "0x3B98c72760f7BBa69D62ED6f48278451251948e7", false},
+		{"hex with mixed casing", "3b98C72760f7BBA69D62ED6F48278451251948e7", "0x3B98c72760f7BBa69D62ED6f48278451251948e7", false},
+		{"hex with 0x", "0x3B98C72760F7BBA69D62ED6F48278451251948E7", "0x3B98c72760f7BBa69D62ED6f48278451251948e7", false},
+		{"invalid hex ethereum address", "0x3B98C72760F7BBA69D62ED6F48278451251948E", "", true},
+		{"invalid Cosmos address", "cosmos18wvvwfmq77a6d8tza4h5sfuy2yj3jj88", "", true},
+		{"empty string", "", "", true},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			hex, err := accountToHex(tc.addrString)
+			require.Equal(t, tc.expectErr, err != nil, err)
+
+			if !tc.expectErr {
+				require.Equal(t, hex, tc.expectedHex)
+			}
+		})
+	}
+}
+
+func TestCosmosToEthereumTypes(t *testing.T) {
+	hexString := "0x3B98D72760f7bbA69d62Ed6F48278451251948E7"
+	cosmosAddr, err := sdk.AccAddressFromHex(hexString[2:])
+	require.NoError(t, err)
+
+	cosmosFormatted := cosmosAddr.String()
+
+	// Test decoding a cosmos formatted address
+	decodedHex, err := accountToHex(cosmosFormatted)
+	require.NoError(t, err)
+	require.Equal(t, hexString, decodedHex)
+
+	// Test converting cosmos address with eth address from hex
+	hexEth := common.HexToAddress(hexString)
+	convertedEth := common.BytesToAddress(cosmosAddr.Bytes())
+	require.Equal(t, hexEth, convertedEth)
+
+	// Test decoding eth hex output against hex string
+	ethDecoded, err := accountToHex(hexEth.Hex())
+	require.NoError(t, err)
+	require.Equal(t, hexString, ethDecoded)
+}

--- a/x/evm/keeper.go
+++ b/x/evm/keeper.go
@@ -138,7 +138,7 @@ func (k *Keeper) SubBalance(ctx sdk.Context, addr ethcmn.Address, amount *big.In
 
 // SetNonce calls CommitStateDB.SetNonce using the passed in context
 func (k *Keeper) SetNonce(ctx sdk.Context, addr ethcmn.Address, nonce uint64) {
-	k.csdb.WithContext(ctx).SetEmintNonce(addr, nonce)
+	k.csdb.WithContext(ctx).SetNonce(addr, nonce)
 }
 
 // SetState calls CommitStateDB.SetState using the passed in context

--- a/x/evm/keeper.go
+++ b/x/evm/keeper.go
@@ -138,7 +138,7 @@ func (k *Keeper) SubBalance(ctx sdk.Context, addr ethcmn.Address, amount *big.In
 
 // SetNonce calls CommitStateDB.SetNonce using the passed in context
 func (k *Keeper) SetNonce(ctx sdk.Context, addr ethcmn.Address, nonce uint64) {
-	k.csdb.WithContext(ctx).SetNonce(addr, nonce)
+	k.csdb.WithContext(ctx).SetEmintNonce(addr, nonce)
 }
 
 // SetState calls CommitStateDB.SetState using the passed in context

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -126,6 +126,9 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		panic(err)
 	}
 
+	// Clear accounts cache after account data has been committed
+	am.keeper.csdb.ClearStateObjects()
+
 	return []abci.ValidatorUpdate{}
 }
 

--- a/x/evm/module.go
+++ b/x/evm/module.go
@@ -120,6 +120,9 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	// Gas costs are handled within msg handler so costs should be ignored
 	ebCtx := ctx.WithBlockGasMeter(sdk.NewInfiniteGasMeter())
 
+	// Update account balances before committing other parts of state
+	am.keeper.csdb.UpdateAccounts()
+
 	// Commit state objects to KV store
 	_, err := am.keeper.csdb.WithContext(ebCtx).Commit(true)
 	if err != nil {

--- a/x/evm/types/codec.go
+++ b/x/evm/types/codec.go
@@ -10,7 +10,6 @@ var ModuleCdc = codec.New()
 func init() {
 	cdc := codec.New()
 
-	RegisterCodec(cdc)
 	codec.RegisterCrypto(cdc)
 
 	ModuleCdc = cdc.Seal()

--- a/x/evm/types/key.go
+++ b/x/evm/types/key.go
@@ -2,7 +2,7 @@ package types
 
 const (
 	// ModuleName string name of module
-	ModuleName = "ethermint"
+	ModuleName = "evm"
 
 	// EvmStoreKey key for ethereum storage data
 	EvmStoreKey = "evmstore"

--- a/x/evm/types/state_transition.go
+++ b/x/evm/types/state_transition.go
@@ -90,19 +90,19 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (*big.Int, sdk.Result)
 	// Get nonce of account outside of the EVM
 	currentNonce := st.Csdb.GetNonce(st.Sender)
 	// Set nonce of sender account before evm state transition for usage in generating Create address
-	st.Csdb.SetEmintNonce(st.Sender, st.AccountNonce)
+	st.Csdb.SetNonce(st.Sender, st.AccountNonce)
 
 	if contractCreation {
 		ret, addr, leftOverGas, vmerr = vmenv.Create(senderRef, st.Payload, gasLimit, st.Amount)
 
 		// Sets the nonce of the created contract to 1
-		st.Csdb.SetEmintNonce(addr, 1)
+		st.Csdb.SetNonce(addr, 1)
 	} else {
 		ret, leftOverGas, vmerr = vmenv.Call(senderRef, *st.Recipient, st.Payload, gasLimit, st.Amount)
 	}
 
 	// Resets nonce to value pre state transition
-	st.Csdb.SetEmintNonce(st.Sender, currentNonce)
+	st.Csdb.SetNonce(st.Sender, currentNonce)
 
 	// Generate bloom filter to be saved in tx receipt data
 	bloomInt := big.NewInt(0)

--- a/x/evm/types/state_transition.go
+++ b/x/evm/types/state_transition.go
@@ -30,11 +30,10 @@ type StateTransition struct {
 
 // TransitionCSDB performs an evm state transition from a transaction
 func (st StateTransition) TransitionCSDB(ctx sdk.Context) (*big.Int, sdk.Result) {
-	contractCreation := st.Recipient == nil
+	// Clear cache of accounts to handle changes outside of the EVM
+	st.Csdb.ClearStateObjects()
 
-	if res := st.checkNonce(); !res.IsOK() {
-		return nil, res
-	}
+	contractCreation := st.Recipient == nil
 
 	cost, err := core.IntrinsicGas(st.Payload, contractCreation, true)
 	if err != nil {
@@ -44,7 +43,7 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (*big.Int, sdk.Result)
 	// This gas limit the the transaction gas limit with intrinsic gas subtracted
 	gasLimit := st.GasLimit - ctx.GasMeter().GasConsumed()
 
-	csdb := st.Csdb
+	csdb := st.Csdb.WithContext(ctx)
 	if st.Simulate {
 		// gasLimit is set here because stdTxs incur gaskv charges in the ante handler, but for eth_call
 		// the cost needs to be the same as an Ethereum transaction sent through the web3 API
@@ -88,13 +87,22 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (*big.Int, sdk.Result)
 		senderRef   = vm.AccountRef(st.Sender)
 	)
 
+	// Get nonce of account outside of the EVM
+	currentNonce := st.Csdb.GetNonce(st.Sender)
+	// Set nonce of sender account before evm state transition for usage in generating Create address
+	st.Csdb.SetEmintNonce(st.Sender, st.AccountNonce)
+
 	if contractCreation {
 		ret, addr, leftOverGas, vmerr = vmenv.Create(senderRef, st.Payload, gasLimit, st.Amount)
+
+		// Sets the nonce of the created contract to 1
+		st.Csdb.SetEmintNonce(addr, 1)
 	} else {
-		// Increment the nonce for the next transaction
-		csdb.SetNonce(st.Sender, csdb.GetNonce(st.Sender)+1)
 		ret, leftOverGas, vmerr = vmenv.Call(senderRef, *st.Recipient, st.Payload, gasLimit, st.Amount)
 	}
+
+	// Resets nonce to value pre state transition
+	st.Csdb.SetEmintNonce(st.Sender, currentNonce)
 
 	// Generate bloom filter to be saved in tx receipt data
 	bloomInt := big.NewInt(0)
@@ -131,19 +139,4 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (*big.Int, sdk.Result)
 	ctx.GasMeter().ConsumeGas(gasLimit-leftOverGas, "EVM execution consumption")
 
 	return bloomInt, sdk.Result{Data: returnData, GasUsed: st.GasLimit - leftOverGas}
-}
-
-func (st *StateTransition) checkNonce() sdk.Result {
-	// If simulated transaction, don't verify nonce
-	if !st.Simulate {
-		// Make sure this transaction's nonce is correct.
-		nonce := st.Csdb.GetNonce(st.Sender)
-		if nonce < st.AccountNonce {
-			return emint.ErrInvalidNonce("nonce too high").Result()
-		} else if nonce > st.AccountNonce {
-			return emint.ErrInvalidNonce("nonce too low").Result()
-		}
-	}
-
-	return sdk.Result{}
 }

--- a/x/evm/types/state_transition.go
+++ b/x/evm/types/state_transition.go
@@ -30,8 +30,6 @@ type StateTransition struct {
 
 // TransitionCSDB performs an evm state transition from a transaction
 func (st StateTransition) TransitionCSDB(ctx sdk.Context) (*big.Int, sdk.Result) {
-	// Clear cache of accounts to handle changes outside of the EVM
-	st.Csdb.ClearStateObjects()
 
 	contractCreation := st.Recipient == nil
 
@@ -57,6 +55,9 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (*big.Int, sdk.Result)
 
 		csdb = st.Csdb.Copy()
 	}
+
+	// Clear cache of accounts to handle changes outside of the EVM
+	csdb.UpdateAccounts()
 
 	// Create context for evm
 	context := vm.Context{

--- a/x/evm/types/state_transition.go
+++ b/x/evm/types/state_transition.go
@@ -95,10 +95,10 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (*big.Int, sdk.Result)
 
 	if contractCreation {
 		ret, addr, leftOverGas, vmerr = vmenv.Create(senderRef, st.Payload, gasLimit, st.Amount)
-
-		// Sets the nonce of the created contract to 1
-		st.Csdb.SetNonce(addr, 1)
 	} else {
+		// Increment the nonce for the next transaction	(just for evm state transition)
+		csdb.SetNonce(st.Sender, csdb.GetNonce(st.Sender)+1)
+
 		ret, leftOverGas, vmerr = vmenv.Call(senderRef, *st.Recipient, st.Payload, gasLimit, st.Amount)
 	}
 

--- a/x/evm/types/statedb.go
+++ b/x/evm/types/statedb.go
@@ -130,8 +130,17 @@ func (csdb *CommitStateDB) SubBalance(addr ethcmn.Address, amount *big.Int) {
 	}
 }
 
-// SetNonce sets the nonce (sequence number) of an account.
+// SetNonce is a no op function which is called inside the EVM
 func (csdb *CommitStateDB) SetNonce(addr ethcmn.Address, nonce uint64) {
+	// ! No op to disable setting nonce from within the EVM state transition
+	// so := csdb.GetOrNewStateObject(addr)
+	// if so != nil {
+	// 	so.SetNonce(nonce)
+	// }
+}
+
+// SetEmintNonce sets the nonce (sequence number) of an account.
+func (csdb *CommitStateDB) SetEmintNonce(addr ethcmn.Address, nonce uint64) {
 	so := csdb.GetOrNewStateObject(addr)
 	if so != nil {
 		so.SetNonce(nonce)
@@ -523,7 +532,7 @@ func (csdb *CommitStateDB) Suicide(addr ethcmn.Address) bool {
 // Reset clears out all ephemeral state objects from the state db, but keeps
 // the underlying account mapper and store keys to avoid reloading data for the
 // next operations.
-func (csdb *CommitStateDB) Reset(root ethcmn.Hash) error {
+func (csdb *CommitStateDB) Reset(_ ethcmn.Hash) error {
 	csdb.stateObjects = make(map[ethcmn.Address]*stateObject)
 	csdb.stateObjectsDirty = make(map[ethcmn.Address]struct{})
 	csdb.thash = ethcmn.Hash{}
@@ -535,6 +544,12 @@ func (csdb *CommitStateDB) Reset(root ethcmn.Hash) error {
 
 	csdb.clearJournalAndRefund()
 	return nil
+}
+
+// ClearStateObjects clears cache of state objects to handle account changes outside of the EVM
+func (csdb *CommitStateDB) ClearStateObjects() {
+	csdb.stateObjects = make(map[ethcmn.Address]*stateObject)
+	csdb.stateObjectsDirty = make(map[ethcmn.Address]struct{})
 }
 
 func (csdb *CommitStateDB) clearJournalAndRefund() {

--- a/x/evm/types/statedb.go
+++ b/x/evm/types/statedb.go
@@ -130,17 +130,8 @@ func (csdb *CommitStateDB) SubBalance(addr ethcmn.Address, amount *big.Int) {
 	}
 }
 
-// SetNonce is a no op function which is called inside the EVM
+// SetNonce sets the nonce (sequence number) of an account.
 func (csdb *CommitStateDB) SetNonce(addr ethcmn.Address, nonce uint64) {
-	// ! No op to disable setting nonce from within the EVM state transition
-	// so := csdb.GetOrNewStateObject(addr)
-	// if so != nil {
-	// 	so.SetNonce(nonce)
-	// }
-}
-
-// SetEmintNonce sets the nonce (sequence number) of an account.
-func (csdb *CommitStateDB) SetEmintNonce(addr ethcmn.Address, nonce uint64) {
 	so := csdb.GetOrNewStateObject(addr)
 	if so != nil {
 		so.SetNonce(nonce)


### PR DESCRIPTION
- Implements #13 #9 #14 which finishes the evm as a module, but a few details will be ironed out before I make this PR open for review

Notes/problems:
- ~~EVM state transition increments nonce in the message handler and uses the current nonce to generate the address that a contract is deployed to~~
  - ~~Naive solution would be to remove the nonce check within the state transition function, add the nonce increase in each ante handler, and reduce the nonce by 1 at the end of the state transition to offset the increase done within the EVM~~
- Unclear which (if at all) rest endpoints will be available for the module. Most queries are irrelevant outside of the web3 rpc API, and there are potential options for allowing the existing code to be compatible with cosmos standard transactions, but unclear the direction.
- ~~Verify and write tests for the inputs of the query~~

Commands include:

```
# Basic send transaction to an account
emintcli tx evm send [address] [amount] <data> --from [key or account]
# Create evm transaction (will return address that contract will be created at)
emintcli tx evm create [bytecode] <amount> --from [key or account]

# Query storage
emintcli query evm storage [account] [key]
# Query code
emintcli query evm code [account]
# Address can be cosmos or ethereum format
```