### PR TITLE
Unsafe export private key command for dev tooling

### DIFF
--- a/cmd/emintcli/export.go
+++ b/cmd/emintcli/export.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/cosmos/cosmos-sdk/client/input"
+	clientkeys "github.com/cosmos/cosmos-sdk/client/keys"
+	emintcrypto "github.com/cosmos/ethermint/crypto"
+)
+
+func exportEthKeyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export-eth-key <name>",
+		Short: "Export an Ethereum private key",
+		Long:  `Export an Ethereum private key unencrypted to use in dev tooling **UNSAFE**`,
+		Args:  cobra.ExactArgs(1),
+		RunE:  runExportCmd,
+	}
+	return cmd
+}
+
+func runExportCmd(cmd *cobra.Command, args []string) error {
+	kb, err := clientkeys.NewKeyBaseFromHomeFlag()
+	if err != nil {
+		return err
+	}
+
+	// Get password from input or standard input
+	buf := bufio.NewReader(cmd.InOrStdin())
+	decryptPassword, err := input.GetPassword(
+		"**WARNING this is an unsafe way to export your unencrypted private key**\nEnter key password:",
+		buf)
+	if err != nil {
+		return err
+	}
+
+	// Exports private key from keybase using password
+	privKey, err := kb.ExportPrivateKeyObject(args[0], decryptPassword)
+	if err != nil {
+		return err
+	}
+
+	// Converts key to Ethermint secp256 implementation
+	emintKey, ok := privKey.(emintcrypto.PrivKeySecp256k1)
+	if !ok {
+		return fmt.Errorf("invalid private key type, must be Ethereum key: %T", privKey)
+	}
+
+	// Formats key for output
+	privB := ethcrypto.FromECDSA(emintKey.ToECDSA())
+	keyS := strings.ToUpper(hexutil.Encode(privB))
+
+	fmt.Println(keyS)
+
+	return nil
+}

--- a/cmd/emintcli/export.go
+++ b/cmd/emintcli/export.go
@@ -55,7 +55,7 @@ func runExportCmd(cmd *cobra.Command, args []string) error {
 
 	// Formats key for output
 	privB := ethcrypto.FromECDSA(emintKey.ToECDSA())
-	keyS := strings.ToUpper(hexutil.Encode(privB))
+	keyS := strings.ToUpper(hexutil.Encode(privB)[2:])
 
 	fmt.Println(keyS)
 

--- a/cmd/emintcli/keys.go
+++ b/cmd/emintcli/keys.go
@@ -42,6 +42,8 @@ func keyCommands() *cobra.Command {
 		clientkeys.UpdateKeyCommand(),
 		clientkeys.ParseKeyStringCommand(),
 		clientkeys.MigrateCommand(),
+		flags.LineBreak,
+		exportEthKeyCommand(),
 	)
 	return cmd
 }


### PR DESCRIPTION
- Issue ref #145 . Although not a safe way to export a private key since it doesn't encrypt with a password and format it the Ethereum way to import into metamask with a password, this way works and should be sufficient for any needs to use Metamask or any other dev tooling until the code is production ready

run with:

```
emintcli keys export-eth-key <key-name>
```