### PR TITLE
Enable Cosmos endpoints on rest-server command

### DIFF
--- a/cmd/emintcli/main.go
+++ b/cmd/emintcli/main.go
@@ -60,8 +60,7 @@ func main() {
 		client.ConfigCmd(emintapp.DefaultCLIHome),
 		queryCmd(cdc),
 		txCmd(cdc),
-		// TODO: Set up rest routes (if included, different from web3 api)
-		rpc.Web3RpcCmd(cdc),
+		rpc.EmintServeCmd(cdc),
 		client.LineBreak,
 		keyCommands(),
 		client.LineBreak,


### PR DESCRIPTION
- #161 Adds the commands necessary

This can be done by adding a seperate command, but I will assume this way until I find or someone brings up a reason to have these servers seperated. For context, the Ethereum RPC API is currently being attached to the Cosmos lcd server but instead of registering the standard routes, the web3 server was being registered to route `/`. 

Since all RPC API requests go through this route, I don't think there is a conflict with the Cosmos routes being registered.