### PR TITLE
add tendermint hash to ethereum hash mapping, add to GetLogs

### DIFF
--- a/rpc/tester/tester_test.go
+++ b/rpc/tester/tester_test.go
@@ -266,9 +266,6 @@ func TestEth_GetTransactionReceipt(t *testing.T) {
 }
 
 func TestEth_GetTxLogs(t *testing.T) {
-	// currently fails due to eth_sendTransaction returning the tendermint hash,
-	// while the logs are stored in the db using the ethereum hash
-	t.Skip()
 	hash := deployTestContract(t)
 
 	time.Sleep(time.Second * 5)

--- a/x/evm/handler.go
+++ b/x/evm/handler.go
@@ -43,21 +43,24 @@ func HandleMsgEthereumTx(ctx sdk.Context, k Keeper, msg types.MsgEthereumTx) sdk
 		return sdk.ResultFromError(err)
 	}
 
+	tmhash := tmtypes.Tx(ctx.TxBytes()).Hash()
 	txHash := msg.Hash()
 
 	st := types.StateTransition{
-		Sender:       sender,
-		AccountNonce: msg.Data.AccountNonce,
-		Price:        msg.Data.Price,
-		GasLimit:     msg.Data.GasLimit,
-		Recipient:    msg.Data.Recipient,
-		Amount:       msg.Data.Amount,
-		Payload:      msg.Data.Payload,
-		Csdb:         k.CommitStateDB.WithContext(ctx),
-		ChainID:      intChainID,
-		THash:        &txHash,
-		Simulate:     ctx.IsCheckTx(),
+		Sender:         sender,
+		AccountNonce:   msg.Data.AccountNonce,
+		Price:          msg.Data.Price,
+		GasLimit:       msg.Data.GasLimit,
+		Recipient:      msg.Data.Recipient,
+		Amount:         msg.Data.Amount,
+		Payload:        msg.Data.Payload,
+		Csdb:           k.CommitStateDB.WithContext(ctx),
+		ChainID:        intChainID,
+		THash:          &txHash,
+		TendermintHash: tmhash,
+		Simulate:       ctx.IsCheckTx(),
 	}
+
 	// Prepare db for logs
 	// TODO: block hash
 	k.CommitStateDB.Prepare(txHash, txHash, k.TxCount)

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -117,7 +117,16 @@ func (k *Keeper) GetTransactionLogs(ctx sdk.Context, hash []byte) ([]*ethtypes.L
 	store := ctx.KVStore(k.blockKey)
 	encLogs := store.Get(types.LogsKey(hash))
 	if len(encLogs) == 0 {
-		return nil, errors.New("cannot get transaction logs")
+
+		ethHash, err := k.CommitStateDB.GetTendermintHashToEthereumHash(hash)
+		if err != nil {
+			return nil, err
+		}
+
+		encLogs = store.Get(types.LogsKey(ethHash))
+		if len(encLogs) == 0 {
+			return nil, errors.New("cannot get transaction logs")
+		}
 	}
 
 	return types.DecodeLogs(encLogs)

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -115,8 +115,8 @@ func (k *Keeper) SetTransactionLogs(ctx sdk.Context, logs []*ethtypes.Log, hash 
 // GetBlockLogs gets the logs for a transaction from the KVStore
 func (k *Keeper) GetTransactionLogs(ctx sdk.Context, hash []byte) ([]*ethtypes.Log, error) {
 	store := ctx.KVStore(k.blockKey)
-	encLogs := []byte{}
 	ethHash := k.CommitStateDB.GetTendermintHashToEthereumHash(hash)
+	var encLogs []byte
 
 	switch {
 	case store.Has(types.LogsKey(hash)):

--- a/x/evm/keeper/querier.go
+++ b/x/evm/keeper/querier.go
@@ -152,7 +152,7 @@ func queryBlockLogsBloom(ctx sdk.Context, path []string, keeper Keeper) ([]byte,
 
 func queryTxLogs(ctx sdk.Context, path []string, keeper Keeper) ([]byte, sdk.Error) {
 	txHash := ethcmn.HexToHash(path[1])
-	logs, err := keeper.GetLogs(ctx, txHash)
+	logs, err := keeper.GetTransactionLogs(ctx, txHash[:])
 	if err != nil {
 		return nil, sdk.ErrInternal(err.Error())
 	}

--- a/x/evm/types/state_transition.go
+++ b/x/evm/types/state_transition.go
@@ -15,17 +15,18 @@ import (
 
 // StateTransition defines data to transitionDB in evm
 type StateTransition struct {
-	Payload      []byte
-	Recipient    *common.Address
-	AccountNonce uint64
-	GasLimit     uint64
-	Price        *big.Int
-	Amount       *big.Int
-	ChainID      *big.Int
-	Csdb         *CommitStateDB
-	THash        *common.Hash
-	Sender       common.Address
-	Simulate     bool
+	Payload        []byte
+	Recipient      *common.Address
+	AccountNonce   uint64
+	GasLimit       uint64
+	Price          *big.Int
+	Amount         *big.Int
+	ChainID        *big.Int
+	Csdb           *CommitStateDB
+	THash          *common.Hash
+	TendermintHash []byte
+	Sender         common.Address
+	Simulate       bool
 }
 
 // ReturnData represents what's returned from a transition
@@ -176,6 +177,8 @@ func (st StateTransition) TransitionCSDB(ctx sdk.Context) (*ReturnData, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	st.Csdb.SetTendermintHashToEthereumHash(st.TendermintHash, (*st.THash)[:])
 
 	returnData.Logs = logs
 	returnData.Bloom = bloomInt

--- a/x/evm/types/statedb.go
+++ b/x/evm/types/statedb.go
@@ -316,8 +316,8 @@ func (csdb *CommitStateDB) GetLogs(hash ethcmn.Hash) ([]*ethtypes.Log, error) {
 		encLogs = store.Get(LogsKey(hash[:]))
 	case store.Has(LogsKey(ethHash)):
 		encLogs = store.Get(LogsKey(ethHash))
-	default:
-		return nil, errors.New("cannot get transaction logs")
+	// default:
+	// 	return nil, errors.New("cannot get transaction logs")
 	}
 
 	if len(encLogs) == 0 {

--- a/x/evm/types/statedb.go
+++ b/x/evm/types/statedb.go
@@ -359,6 +359,24 @@ func (csdb *CommitStateDB) StorageTrie(addr ethcmn.Address) ethstate.Trie {
 	return nil
 }
 
+// SetTendermintHashToEthereumHash sets the tendermint hash to ethereum hash mapping
+func (csdb *CommitStateDB) SetTendermintHashToEthereumHash(tmhash []byte, ethhash []byte) {
+	store := csdb.ctx.KVStore(csdb.storeKey)
+	store.Set(tmhash, ethhash)
+}
+
+// GetTendermintHashToEthereumHash retrieves the ethereum hash given the tendermint hash
+func (csdb *CommitStateDB) GetTendermintHashToEthereumHash(tmhash []byte) ([]byte, error) {
+	store := csdb.ctx.KVStore(csdb.storeKey)
+
+	ethhash := store.Get(tmhash)
+	if len(ethhash) == 0 {
+		return nil, fmt.Errorf("cannot get ethereum hash from tendermint hash %x", tmhash)
+	}
+
+	return ethhash, nil
+}
+
 // ----------------------------------------------------------------------------
 // Persistence
 // ----------------------------------------------------------------------------

--- a/x/evm/types/statedb.go
+++ b/x/evm/types/statedb.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"sort"
@@ -310,7 +311,15 @@ func (csdb *CommitStateDB) GetLogs(hash ethcmn.Hash) ([]*ethtypes.Log, error) {
 
 	encLogs := store.Get(LogsKey(hash[:]))
 	if len(encLogs) == 0 {
-		return []*ethtypes.Log{}, nil
+		ethHash, err := csdb.GetTendermintHashToEthereumHash(hash[:])
+		if err != nil {
+			return nil, err
+		}
+
+		encLogs = store.Get(LogsKey(ethHash))
+		if len(encLogs) == 0 {
+			return nil, errors.New("cannot get transaction logs")
+		}
 	}
 
 	logs, err := DecodeLogs(encLogs)

--- a/x/evm/types/statedb.go
+++ b/x/evm/types/statedb.go
@@ -313,7 +313,7 @@ func (csdb *CommitStateDB) GetLogs(hash ethcmn.Hash) ([]*ethtypes.Log, error) {
 	if len(encLogs) == 0 {
 		ethHash, err := csdb.GetTendermintHashToEthereumHash(hash[:])
 		if err != nil {
-			return nil, err
+			return nil, nil
 		}
 
 		encLogs = store.Get(LogsKey(ethHash))

--- a/x/evm/types/statedb.go
+++ b/x/evm/types/statedb.go
@@ -308,18 +308,20 @@ func (csdb *CommitStateDB) GetLogs(hash ethcmn.Hash) ([]*ethtypes.Log, error) {
 	}
 
 	store := csdb.ctx.KVStore(csdb.storeKey)
+	ethHash := csdb.GetTendermintHashToEthereumHash(hash[:])
 
-	encLogs := store.Get(LogsKey(hash[:]))
-	if len(encLogs) == 0 {
-		ethHash, err := csdb.GetTendermintHashToEthereumHash(hash[:])
-		if err != nil {
-			return nil, nil
-		}
-
+	encLogs := []byte{}
+	switch {
+	case store.Has(LogsKey(hash[:])):
+		encLogs = store.Get(LogsKey(hash[:]))
+	case store.Has(LogsKey(ethHash)):
 		encLogs = store.Get(LogsKey(ethHash))
-		if len(encLogs) == 0 {
-			return nil, errors.New("cannot get transaction logs")
-		}
+	default:
+		return nil, errors.New("cannot get transaction logs")
+	}
+
+	if len(encLogs) == 0 {
+		return nil, errors.New("cannot get transaction logs")
 	}
 
 	logs, err := DecodeLogs(encLogs)
@@ -375,15 +377,10 @@ func (csdb *CommitStateDB) SetTendermintHashToEthereumHash(tmhash []byte, ethhas
 }
 
 // GetTendermintHashToEthereumHash retrieves the ethereum hash given the tendermint hash
-func (csdb *CommitStateDB) GetTendermintHashToEthereumHash(tmhash []byte) ([]byte, error) {
+func (csdb *CommitStateDB) GetTendermintHashToEthereumHash(tmhash []byte) []byte {
 	store := csdb.ctx.KVStore(csdb.storeKey)
 
-	ethhash := store.Get(tmhash)
-	if len(ethhash) == 0 {
-		return nil, fmt.Errorf("cannot get ethereum hash from tendermint hash %x", tmhash)
-	}
-
-	return ethhash, nil
+	return store.Get(tmhash)
 }
 
 // ----------------------------------------------------------------------------

--- a/x/evm/types/statedb.go
+++ b/x/evm/types/statedb.go
@@ -316,8 +316,8 @@ func (csdb *CommitStateDB) GetLogs(hash ethcmn.Hash) ([]*ethtypes.Log, error) {
 		encLogs = store.Get(LogsKey(hash[:]))
 	case store.Has(LogsKey(ethHash)):
 		encLogs = store.Get(LogsKey(ethHash))
-	// default:
-	// 	return nil, errors.New("cannot get transaction logs")
+	default:
+		return nil, errors.New("cannot get transaction logs")
 	}
 
 	if len(encLogs) == 0 {

--- a/x/evm/types/statedb.go
+++ b/x/evm/types/statedb.go
@@ -310,7 +310,7 @@ func (csdb *CommitStateDB) GetLogs(hash ethcmn.Hash) ([]*ethtypes.Log, error) {
 	store := csdb.ctx.KVStore(csdb.storeKey)
 	ethHash := csdb.GetTendermintHashToEthereumHash(hash[:])
 
-	encLogs := []byte{}
+	var encLogs []byte
 	switch {
 	case store.Has(LogsKey(hash[:])):
 		encLogs = store.Get(LogsKey(hash[:]))


### PR DESCRIPTION
## Description

- eth_sendTransaction returns the tendermint hash, but logs are stored via the ethereum hash (since blocks contain ethereum hashes, filter needs to look it up that way)
- add SetTendermintHashToEthereumHash and GetTendermintHashToEthereumHash to csdb
- SetTendermintHashToEthereumHash is called in state_transition, GetTendermintHashToEthereumHash is called in GetLogs

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
