### PR TITLE
fix transaction receipts 

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -707,7 +707,6 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (map[string]inter
 	e.cliCtx.Codec.MustUnmarshalJSON(res, &logs)
 
 	txData := tx.TxResult.GetData()
-	fmt.Println(txData)
 
 	data, err := types.DecodeResultData(txData)
 	if err != nil {

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -703,13 +703,16 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (*ethtypes.Receip
 		return nil, err
 	}
 
-	fmt.Println(data)
+	fmt.Println(data.Logs)
+
+	postState := [32]byte{}
 
 	receipt := &ethtypes.Receipt{
+		PostState:         postState[:],
 		Status:            status,
 		CumulativeGasUsed: uint64(tx.TxResult.GasUsed),
 		Bloom:             data.Bloom,
-		Logs:              logs.Logs,
+		Logs:              []*ethtypes.Log{},
 		TxHash:            hash,
 		GasUsed:           uint64(tx.TxResult.GasUsed),
 		BlockHash:         blockHash,

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -710,7 +710,7 @@ func (e *PublicEthAPI) GetTransactionReceipt(hash common.Hash) (*ethtypes.Receip
 	receipt := &ethtypes.Receipt{
 		PostState:         postState[:],
 		Status:            status,
-		CumulativeGasUsed: uint64(tx.TxResult.GasUsed),
+		CumulativeGasUsed: uint64(tx.TxResult.GasUsed), // TODO: update this to include gasUsed from other txs
 		Bloom:             data.Bloom,
 		Logs:              []*ethtypes.Log{},
 		TxHash:            hash,

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cosmos/ethermint/version"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -324,6 +325,7 @@ func TestEth_GetTransactionReceipt_ContractDeployment(t *testing.T) {
 	err = receipt.UnmarshalJSON(rpcRes.Result)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), receipt.Status)
+	require.NotEqual(t, common.Address{}, receipt.ContractAddress)
 	// TODO: assert logs exist
 }
 

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -34,7 +34,7 @@ const (
 
 var (
 	ETHERMINT_INTEGRATION_TEST_MODE = os.Getenv("ETHERMINT_INTEGRATION_TEST_MODE")
-	ETHERMINT_NODE_HOST             = "http://localhost:8545" //os.Getenv("ETHERMINT_NODE_HOST")
+	ETHERMINT_NODE_HOST             = os.Getenv("ETHERMINT_NODE_HOST")
 
 	zeroString = "0x0"
 )
@@ -58,21 +58,21 @@ type Response struct {
 	Result json.RawMessage `json:"result,omitempty"`
 }
 
-// func TestMain(m *testing.M) {
-// 	if ETHERMINT_INTEGRATION_TEST_MODE != "stable" {
-// 		_, _ = fmt.Fprintln(os.Stdout, "Going to skip stable test")
-// 		return
-// 	}
+func TestMain(m *testing.M) {
+	if ETHERMINT_INTEGRATION_TEST_MODE != "stable" {
+		_, _ = fmt.Fprintln(os.Stdout, "Going to skip stable test")
+		return
+	}
 
-// 	if ETHERMINT_NODE_HOST == "" {
-// 		_, _ = fmt.Fprintln(os.Stdout, "Going to skip stable test, ETHERMINT_NODE_HOST is not defined")
-// 		return
-// 	}
+	if ETHERMINT_NODE_HOST == "" {
+		_, _ = fmt.Fprintln(os.Stdout, "Going to skip stable test, ETHERMINT_NODE_HOST is not defined")
+		return
+	}
 
-// 	// Start all tests
-// 	code := m.Run()
-// 	os.Exit(code)
-// }
+	// Start all tests
+	code := m.Run()
+	os.Exit(code)
+}
 
 func createRequest(method string, params interface{}) Request {
 	return Request{

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/cosmos/ethermint/version"
-	"github.com/ethereum/go-ethereum/common"
+	ethcmn "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/require"
@@ -286,10 +286,10 @@ func TestEth_GetTransactionReceipt(t *testing.T) {
 	rpcRes, err := call(t, "eth_getTransactionReceipt", param)
 	require.NoError(t, err)
 
-	receipt := new(ethtypes.Receipt)
-	err = receipt.UnmarshalJSON(rpcRes.Result)
+	receipt := make(map[string]interface{})
+	err = json.Unmarshal(rpcRes.Result, &receipt)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), receipt.Status)
+	require.Equal(t, "0x1", receipt["status"].(string))
 }
 
 // deployTestContract deploys a contract that emits an event in the constructor
@@ -321,11 +321,12 @@ func TestEth_GetTransactionReceipt_ContractDeployment(t *testing.T) {
 	rpcRes, err := call(t, "eth_getTransactionReceipt", param)
 	require.NoError(t, err)
 
-	receipt := new(ethtypes.Receipt)
-	err = receipt.UnmarshalJSON(rpcRes.Result)
+	receipt := make(map[string]interface{})
+	err = json.Unmarshal(rpcRes.Result, &receipt)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), receipt.Status)
-	require.NotEqual(t, common.Address{}, receipt.ContractAddress)
+	require.Equal(t, "0x1", receipt["status"].(string))
+
+	require.NotEqual(t, ethcmn.Address{}.String(), receipt["contractAddress"].(string))
 	// TODO: assert logs exist
 }
 

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -278,7 +278,7 @@ func sendTestTransaction(t *testing.T) hexutil.Bytes {
 }
 
 func TestEth_GetTransactionReceipt(t *testing.T) {
-	hash := deployTestContract(t)
+	hash := sendTestTransaction(t)
 
 	time.Sleep(time.Second * 5)
 

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -285,8 +285,10 @@ func TestEth_GetTransactionReceipt(t *testing.T) {
 	rpcRes, err := call(t, "eth_getTransactionReceipt", param)
 	require.NoError(t, err)
 
-	t.Log(rpcRes.Result)
-	// TODO: why does this not return a receipt?
+	receipt := new(ethtypes.Receipt)
+	err = receipt.UnmarshalJSON(rpcRes.Result)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), receipt.Status)
 }
 
 // deployTestContract deploys a contract that emits an event in the constructor
@@ -297,7 +299,7 @@ func deployTestContract(t *testing.T) hexutil.Bytes {
 	param[0] = make(map[string]string)
 	param[0]["from"] = "0x" + fmt.Sprintf("%x", from)
 	param[0]["data"] = "0x60806040526000805534801561001457600080fd5b5060d2806100236000396000f3fe6080604052348015600f57600080fd5b5060043610603c5760003560e01c80634f2be91f1460415780636deebae31460495780638ada066e146051575b600080fd5b6047606d565b005b604f6080565b005b60576094565b6040518082815260200191505060405180910390f35b6000808154809291906001019190505550565b600080815480929190600190039190505550565b6000805490509056fea265627a7a723158207b1aaa18c3100d8aa67f26a53f3cb83d2c69342d17327bd11e1b17c248957bfa64736f6c634300050c0032"
-	param[0]["gasLimit"] = "200000"
+	param[0]["gas"] = "0x200000"
 
 	rpcRes, err := call(t, "eth_sendTransaction", param)
 	require.NoError(t, err)
@@ -318,8 +320,11 @@ func TestEth_GetTransactionReceipt_ContractDeployment(t *testing.T) {
 	rpcRes, err := call(t, "eth_getTransactionReceipt", param)
 	require.NoError(t, err)
 
-	t.Log(rpcRes.Result)
-	// TODO: why does this not return a receipt?
+	receipt := new(ethtypes.Receipt)
+	err = receipt.UnmarshalJSON(rpcRes.Result)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), receipt.Status)
+	// TODO: assert logs exist
 }
 
 func TestEth_GetTxLogs(t *testing.T) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #261 

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

- fix GetTransactionReceipt to return status=0 when no txData exists (since that means tx failed, but sdk doesn't set status to 0)
- add test for getting receipt from non-contract deployment transaction
- receipts working for the ethermnt deploy script and curl

Test instructions:
```
ETHERMINT_NODE_HOST=http://localhost:8545 ETHERMINT_INTEGRATION_TEST_MODE=stable go test ./tests/... -test.v -test.run ^TestEth_GetTransactionReceipt
```

curl instructions:
start daemon + client, then:

```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_accounts","params":[],"id":1}' -H "Content-Type: application/json" http://localhost:8545``
```

use resulting account as `from` of next step:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"data":"0x60806040526000805534801561001457600080fd5b5060d2806100236000396000f3fe6080604052348015600f57600080fd5b5060043610603c5760003560e01c80634f2be91f1460415780636deebae31460495780638ada066e146051575b600080fd5b6047606d565b005b604f6080565b005b60576094565b6040518082815260200191505060405180910390f35b6000808154809291906001019190505550565b600080815480929190600190039190505550565b6000805490509056fea265627a7a723158207b1aaa18c3100d8aa67f26a53f3cb83d2c69342d17327bd11e1b17c248957bfa64736f6c634300050c0032","from":"0xbda0d762653c606f9ee2e9e04eb6dd880d9c9db7"}],"id":1}' -H "Content-Type: application/json" http://localhost:8545
```

then use resulting hash in next step:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xc425cfa420e1a7b8ab57329e24666d3cc2e4cb1058e946c17726e3fb96a76153"],"id":1}' -H "Content-Type: application/json" http://localhost:8545
```

also, can do `node web3/deploy_contract.js` in ethermint-deploy repo (make sure to pull master)

______


For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
