### PR TITLE
change eth_estimateGas to return hexutil.Uint64

### DIFF
--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -477,7 +477,7 @@ func (e *PublicEthAPI) doCall(
 // EstimateGas returns an estimate of gas usage for the given smart contract call.
 // It adds 1,000 gas to the returned value instead of using the gas adjustment
 // param from the SDK.
-func (e *PublicEthAPI) EstimateGas(args CallArgs) (uint64, error) {
+func (e *PublicEthAPI) EstimateGas(args CallArgs) (hexutil.Uint64, error) {
 	simResponse, err := e.doCall(args, 0, big.NewInt(emint.DefaultRPCGasLimit))
 	if err != nil {
 		return 0, err
@@ -486,7 +486,9 @@ func (e *PublicEthAPI) EstimateGas(args CallArgs) (uint64, error) {
 	// TODO: change 1000 buffer for more accurate buffer (eg: SDK's gasAdjusted)
 	estimatedGas := simResponse.GasInfo.GasUsed
 	gas := estimatedGas + 1000
-	return gas, nil
+
+	ret := hexutil.Uint64(gas)
+	return ret, nil
 }
 
 // GetBlockByHash returns the block identified by hash.
@@ -910,10 +912,11 @@ func (e *PublicEthAPI) generateFromArgs(args params.SendTxArgs) (*types.MsgEther
 			Value:    args.Value,
 			Data:     args.Data,
 		}
-		gasLimit, err = e.EstimateGas(callArgs)
+		gl, err := e.EstimateGas(callArgs)
 		if err != nil {
 			return nil, err
 		}
+		gasLimit = uint64(gl)
 	} else {
 		gasLimit = (uint64)(*args.Gas)
 	}

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -487,8 +487,7 @@ func (e *PublicEthAPI) EstimateGas(args CallArgs) (hexutil.Uint64, error) {
 	estimatedGas := simResponse.GasInfo.GasUsed
 	gas := estimatedGas + 1000
 
-	ret := hexutil.Uint64(gas)
-	return ret, nil
+	return hexutil.Uint64(gas), nil
 }
 
 // GetBlockByHash returns the block identified by hash.

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -655,3 +655,26 @@ func TestEth_GetTransactionCount(t *testing.T) {
 	post := getNonce(t)
 	require.Equal(t, prev, post-1)
 }
+
+// estimateGas sends a dummy transaction
+func estimateGas(t *testing.T) hexutil.Bytes {
+	from := getAddress(t)
+	param := make([]map[string]string, 1)
+	param[0] = make(map[string]string)
+	param[0]["from"] = "0x" + fmt.Sprintf("%x", from)
+	param[0]["to"] = "0x1122334455667788990011223344556677889900"
+	param[0]["value"] = "0x1"
+	rpcRes := call(t, "eth_estimateGas", param)
+
+	t.Log(rpcRes)
+	var gas hexutil.Bytes
+	err := json.Unmarshal(rpcRes.Result, &gas)
+	require.NoError(t, err)
+	return gas
+}
+
+func TestEth_EstimateGas(t *testing.T) {
+	gas := estimateGas(t)
+	t.Log(gas)
+	require.Equal(t, hexutil.Bytes{0xf7, 0xa6}, gas)
+}

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -656,8 +656,7 @@ func TestEth_GetTransactionCount(t *testing.T) {
 	require.Equal(t, prev, post-1)
 }
 
-// estimateGas sends a dummy transaction
-func estimateGas(t *testing.T) hexutil.Bytes {
+func TestEth_EstimateGas(t *testing.T) {
 	from := getAddress(t)
 	param := make([]map[string]string, 1)
 	param[0] = make(map[string]string)
@@ -666,15 +665,9 @@ func estimateGas(t *testing.T) hexutil.Bytes {
 	param[0]["value"] = "0x1"
 	rpcRes := call(t, "eth_estimateGas", param)
 
-	t.Log(rpcRes)
 	var gas hexutil.Bytes
 	err := json.Unmarshal(rpcRes.Result, &gas)
 	require.NoError(t, err)
-	return gas
-}
 
-func TestEth_EstimateGas(t *testing.T) {
-	gas := estimateGas(t)
-	t.Log(gas)
 	require.Equal(t, hexutil.Bytes{0xf7, 0xa6}, gas)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #296

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

- update eth_estimateGas to return hexutil.Uint64 as expected: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_estimategas
- add test case
- also, metamask no longer has "failed to estimate gas" in its logs (metamask -> settings -> advanced -> download state logs)

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

