### PR TITLE
fix account sending from new accounts

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -1,8 +1,6 @@
 package ante
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth"
@@ -153,9 +151,7 @@ func (asd AccountSetupDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate
 
 	acc := asd.ak.GetAccount(ctx, msg.From)
 	if acc == nil {
-		fmt.Println("failed to get account from keeper, creating new account")
 		info := asd.ak.NewAccountWithAddress(ctx, msg.From)
-		fmt.Println(info)
 		asd.ak.SetAccount(ctx, info)
 	}
 

--- a/app/ante/eth.go
+++ b/app/ante/eth.go
@@ -191,7 +191,11 @@ func (avd AccountVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, s
 
 	acc := avd.ak.GetAccount(ctx, address)
 	if acc == nil {
-		return ctx, fmt.Errorf("account %s (%s) is nil", common.BytesToAddress(address.Bytes()), address)
+		fmt.Println("AccountVerificationDecorator failed to get acc, creating new acc")
+		acc = avd.ak.NewAccountWithAddress(ctx, address)
+		fmt.Println(acc)
+		avd.ak.SetAccount(ctx, acc)
+		//return ctx, fmt.Errorf("account %s (%s) is nil", common.BytesToAddress(address.Bytes()), address)
 	}
 
 	// on InitChain make sure account number == 0
@@ -245,6 +249,7 @@ func (nvd NonceVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, sim
 
 	acc := nvd.ak.GetAccount(ctx, address)
 	if acc == nil {
+		fmt.Println("NonceVerificationDecorator failed to get acc")
 		return ctx, fmt.Errorf("account %s (%s) is nil", common.BytesToAddress(address.Bytes()), address)
 	}
 
@@ -302,6 +307,7 @@ func (egcd EthGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 	}
 
 	if senderAcc == nil {
+		fmt.Println("EthGasConsumeDecorator failed to get acc")
 		return ctx, fmt.Errorf("sender account %s (%s) is nil", common.BytesToAddress(address.Bytes()), address)
 	}
 

--- a/app/ante/eth.go
+++ b/app/ante/eth.go
@@ -191,11 +191,8 @@ func (avd AccountVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, s
 
 	acc := avd.ak.GetAccount(ctx, address)
 	if acc == nil {
-		fmt.Println("AccountVerificationDecorator failed to get acc, creating new acc")
 		acc = avd.ak.NewAccountWithAddress(ctx, address)
-		fmt.Println(acc)
 		avd.ak.SetAccount(ctx, acc)
-		//return ctx, fmt.Errorf("account %s (%s) is nil", common.BytesToAddress(address.Bytes()), address)
 	}
 
 	// on InitChain make sure account number == 0
@@ -249,7 +246,6 @@ func (nvd NonceVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, sim
 
 	acc := nvd.ak.GetAccount(ctx, address)
 	if acc == nil {
-		fmt.Println("NonceVerificationDecorator failed to get acc")
 		return ctx, fmt.Errorf("account %s (%s) is nil", common.BytesToAddress(address.Bytes()), address)
 	}
 
@@ -307,7 +303,6 @@ func (egcd EthGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 	}
 
 	if senderAcc == nil {
-		fmt.Println("EthGasConsumeDecorator failed to get acc")
 		return ctx, fmt.Errorf("sender account %s (%s) is nil", common.BytesToAddress(address.Bytes()), address)
 	}
 

--- a/rpc/eth_api.go
+++ b/rpc/eth_api.go
@@ -1006,11 +1006,6 @@ func (e *PublicEthAPI) generateFromArgs(args params.SendTxArgs) (*evmtypes.MsgEt
 			return nil, fmt.Errorf("cliCtx.Keybase is nil")
 		}
 
-		infos, _ := e.cliCtx.Keybase.List()
-		for _, info := range infos {
-			e.logger.Info("generateFromArgs", "key info", info, "name", info.GetName())
-		}
-
 		err = accRet.EnsureExists(from)
 		if err != nil {
 			// account doesn't exist

--- a/rpc/personal_api.go
+++ b/rpc/personal_api.go
@@ -79,6 +79,7 @@ func (e *PersonalEthAPI) getKeybaseInfo() ([]keys.Info, error) {
 // encrypting it with the passphrase.
 // Currently, this is not implemented since the feature is not supported by the keys.
 func (e *PersonalEthAPI) ImportRawKey(privkey, password string) (common.Address, error) {
+	e.logger.Debug("personal_importRawKey", "error", "not implemented")
 	_, err := crypto.HexToECDSA(privkey)
 	if err != nil {
 		return common.Address{}, err
@@ -89,6 +90,7 @@ func (e *PersonalEthAPI) ImportRawKey(privkey, password string) (common.Address,
 
 // ListAccounts will return a list of addresses for accounts this node manages.
 func (e *PersonalEthAPI) ListAccounts() ([]common.Address, error) {
+	e.logger.Debug("personal_listAccounts")
 	addrs := []common.Address{}
 	for _, info := range e.keyInfos {
 		addressBytes := info.GetPubKey().Address().Bytes()
@@ -101,6 +103,7 @@ func (e *PersonalEthAPI) ListAccounts() ([]common.Address, error) {
 // LockAccount will lock the account associated with the given address when it's unlocked.
 // It removes the key corresponding to the given address from the API's local keys.
 func (e *PersonalEthAPI) LockAccount(address common.Address) bool {
+	e.logger.Debug("personal_lockAccount", "address", address)
 	for i, key := range e.keys {
 		if !bytes.Equal(key.PubKey().Address().Bytes(), address.Bytes()) {
 			continue
@@ -130,6 +133,7 @@ func (e *PersonalEthAPI) LockAccount(address common.Address) bool {
 
 // NewAccount will create a new account and returns the address for the new account.
 func (e *PersonalEthAPI) NewAccount(password string) (common.Address, error) {
+	e.logger.Debug("personal_newAccount")
 	_, err := e.getKeybaseInfo()
 	if err != nil {
 		return common.Address{}, err
@@ -168,6 +172,7 @@ func (e *PersonalEthAPI) NewAccount(password string) (common.Address, error) {
 // default of 300 seconds. It returns an indication if the account was unlocked.
 // It exports the private key corresponding to the given address from the keyring and stores it in the API's local keys.
 func (e *PersonalEthAPI) UnlockAccount(ctx context.Context, addr common.Address, password string, _ *uint64) (bool, error) {
+	e.logger.Debug("personal_unlockAccount", "address", addr)
 	// TODO: use duration
 
 	name := ""
@@ -217,6 +222,8 @@ func (e *PersonalEthAPI) SendTransaction(ctx context.Context, args params.SendTx
 //
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_sign
 func (e *PersonalEthAPI) Sign(ctx context.Context, data hexutil.Bytes, addr common.Address, passwd string) (hexutil.Bytes, error) {
+	e.logger.Debug("personal_sign", "data", data, "address", addr)
+
 	key, ok := checkKeyInKeyring(e.keys, addr)
 	if !ok {
 		return nil, fmt.Errorf("cannot find key with given address")
@@ -242,6 +249,8 @@ func (e *PersonalEthAPI) Sign(ctx context.Context, data hexutil.Bytes, addr comm
 //
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_ecRecove
 func (e *PersonalEthAPI) EcRecover(ctx context.Context, data, sig hexutil.Bytes) (common.Address, error) {
+	e.logger.Debug("personal_ecRecover", "data", data, "sig", sig)
+
 	if len(sig) != crypto.SignatureLength {
 		return common.Address{}, fmt.Errorf("signature must be %d bytes long", crypto.SignatureLength)
 	}

--- a/rpc/personal_api.go
+++ b/rpc/personal_api.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"sync"
 	"time"
@@ -16,6 +15,7 @@ import (
 	emintcrypto "github.com/cosmos/ethermint/crypto"
 	params "github.com/cosmos/ethermint/rpc/args"
 	"github.com/spf13/viper"
+	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -25,6 +25,7 @@ import (
 
 // PersonalEthAPI is the eth_ prefixed set of APIs in the Web3 JSON-RPC spec.
 type PersonalEthAPI struct {
+	logger      log.Logger
 	cliCtx      sdkcontext.CLIContext
 	ethAPI      *PublicEthAPI
 	nonceLock   *AddrLocker
@@ -36,6 +37,7 @@ type PersonalEthAPI struct {
 // NewPersonalEthAPI creates an instance of the public ETH Web3 API.
 func NewPersonalEthAPI(cliCtx sdkcontext.CLIContext, ethAPI *PublicEthAPI, nonceLock *AddrLocker, keys []emintcrypto.PrivKeySecp256k1) *PersonalEthAPI {
 	api := &PersonalEthAPI{
+		logger:    log.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "json-rpc"),
 		cliCtx:    cliCtx,
 		ethAPI:    ethAPI,
 		nonceLock: nonceLock,
@@ -111,6 +113,18 @@ func (e *PersonalEthAPI) LockAccount(address common.Address) bool {
 		return true
 	}
 
+	for i, key := range e.ethAPI.keys {
+		if !bytes.Equal(key.PubKey().Address().Bytes(), address.Bytes()) {
+			continue
+		}
+
+		tmp := make([]emintcrypto.PrivKeySecp256k1, len(e.ethAPI.keys)-1)
+		copy(tmp[:i], e.ethAPI.keys[:i])
+		copy(tmp[i:], e.ethAPI.keys[i+1:])
+		e.ethAPI.keys = tmp
+		return true
+	}
+
 	return false
 }
 
@@ -129,10 +143,23 @@ func (e *PersonalEthAPI) NewAccount(password string) (common.Address, error) {
 
 	e.keyInfos = append(e.keyInfos, info)
 
+	// update ethAPI
+	privKey, err := e.cliCtx.Keybase.ExportPrivateKeyObject(name, password)
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	emintKey, ok := privKey.(emintcrypto.PrivKeySecp256k1)
+	if !ok {
+		return common.Address{}, fmt.Errorf("invalid private key type: %T", privKey)
+	}
+	e.ethAPI.keys = append(e.ethAPI.keys, emintKey)
+	e.logger.Debug("personal_newAccount", "address", fmt.Sprintf("0x%x", emintKey.PubKey().Address().Bytes()))
+
 	addr := common.BytesToAddress(info.GetPubKey().Address().Bytes())
-	log.Printf("Your new key was generated\t\taddress=0x%x", addr)
-	log.Printf("Please backup your key file!\tpath=%s", os.Getenv("HOME")+"/.ethermintcli/"+name)
-	log.Println("Please remember your password!")
+	e.logger.Info("Your new key was generated", "address", addr)
+	e.logger.Info("Please backup your key file!", "path", os.Getenv("HOME")+"/.ethermintcli/"+name)
+	e.logger.Info("Please remember your password!")
 	return addr, nil
 }
 
@@ -167,6 +194,9 @@ func (e *PersonalEthAPI) UnlockAccount(ctx context.Context, addr common.Address,
 	}
 
 	e.keys = append(e.keys, emintKey)
+	e.ethAPI.keys = append(e.ethAPI.keys, emintKey)
+	e.logger.Debug("personal_unlockAccount", "address", fmt.Sprintf("0x%x", emintKey.PubKey().Address().Bytes()))
+
 	return true, nil
 }
 

--- a/tests/personal_test.go
+++ b/tests/personal_test.go
@@ -20,7 +20,7 @@ func TestPersonal_ListAccounts(t *testing.T) {
 }
 
 func TestPersonal_NewAccount(t *testing.T) {
-	rpcRes := call(t, "personal_newAccount", []string{""})
+	rpcRes := call(t, "personal_newAccount", []string{"password"})
 	var addr common.Address
 	err := json.Unmarshal(rpcRes.Result, &addr)
 	require.NoError(t, err)

--- a/tests/rpc_test.go
+++ b/tests/rpc_test.go
@@ -758,7 +758,7 @@ func TestEth_EstimateGas(t *testing.T) {
 	err := json.Unmarshal(rpcRes.Result, &gas)
 	require.NoError(t, err, string(rpcRes.Result))
 
-	require.Equal(t, "0xef7e", gas)
+	require.Equal(t, "0xf552", gas)
 }
 
 func TestEth_EstimateGas_ContractDeployment(t *testing.T) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

- update ante handler to set new accounts in the keeper if an account is not found
- allows accounts made with `personal_newAccount` to send transactions
- also update personal api logs

to test:
```
make install
./init.sh
```
start rpc server as usual

```
geth attach http://localhost:8545
> personal.newAccount("password")
"<new address>"
> personal.unlockAccount("<new address>", "password")
true
> eth.sendTransaction({from: <first account that has balance>, to: <new address>, value: 0x1000000000})
<tx hash>
> eth.sendTransaction({from: <new account>, to: <any other address>, value: 0x1})
```

can use `eth.accounts[0]`, `eth.accounts[1]` etc so you don't need to copy paste addrs
______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
