### PR TITLE
Rpcapi fix - requires Eth namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Unreleased
+
+### API Breaking
+* (eth) [\#845](https://github.com/cosmos/ethermint/pull/845) The `eth` namespace must be included in the list of API's as default to run the rpc server without error.
+
 ## [v0.4.1] - 2021-03-01
 
 ### API Breaking

--- a/docs/guides/join_network.md
+++ b/docs/guides/join_network.md
@@ -13,7 +13,7 @@ This document outlines the steps to join the public testnet hosted by [Chainsafe
     ```bash
     git clone https://github.com/cosmos/ethermint
     cd ethermint
-    git checkout v0.3.1
+    git checkout v0.4.1
     make install
     ```
 
@@ -32,7 +32,7 @@ This document outlines the steps to join the public testnet hosted by [Chainsafe
     Edit the file located in ~/.ethermintd/config/config.toml and edit line 350 (persistent_peers) to the following
 
     ```toml
-    "7678d52de4a724e468e503a7743664d12a78b5b0@18.204.206.179:26656,c62fadc76b7fa1ab25669b64fdc00c8d8d422bd0@3.86.104.251:26656,5fa7d4550b57298b059d1dd8af01829482e7d097@54.210.246.165:26656"
+    "05aa6587f07a0c6a9a8213f0138c4a76d476418a@18.204.206.179:26656,13d4a1c16d1f427988b7c499b6d150726aaf3aa0@3.86.104.251:26656,a00db749fa51e485c8376276d29d599258052f3e@54.210.246.165:26656"
     ```
 
 5. Validate genesis and start the Ethermint network
@@ -40,7 +40,7 @@ This document outlines the steps to join the public testnet hosted by [Chainsafe
     ```bash
     ethermintd validate-genesis
 
-    ethermintd start --pruning=nothing --rpc.unsafe --log_level "main:info,state:info,mempool:info" --trace
+    ethermintd start --pruning=nothing --rpc.unsafe --log_level "main:info,state:info,mempool:info" --trace --rpc-api "web3,eth,net,personal"
     ```
 
     (we recommend running the command in the background for convenience)

--- a/docs/guides/join_network.md
+++ b/docs/guides/join_network.md
@@ -40,7 +40,7 @@ This document outlines the steps to join the public testnet hosted by [Chainsafe
     ```bash
     ethermintd validate-genesis
 
-    ethermintd start --pruning=nothing --rpc.unsafe --log_level "main:info,state:info,mempool:info" --trace --rpc-api "web3,eth,net,personal"
+    ethermintd start --pruning=nothing --rpc.unsafe --log_level "main:info,state:info,mempool:info" --trace
     ```
 
     (we recommend running the command in the background for convenience)

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -34,6 +34,23 @@ func GetAPIs(clientCtx context.CLIContext, selectedApis []string, keys ...ethsec
 
 	var apis []rpc.API
 
+	apis = append(apis,
+		rpc.API{
+			Namespace: EthNamespace,
+			Version:   apiVersion,
+			Service:   ethAPI,
+			Public:    true,
+		},
+	)
+	apis = append(apis,
+		rpc.API{
+			Namespace: EthNamespace,
+			Version:   apiVersion,
+			Service:   filters.NewAPI(clientCtx, backend),
+			Public:    true,
+		},
+	)
+
 	for _, api := range selectedApis {
 		switch api {
 		case Web3Namespace:
@@ -42,23 +59,6 @@ func GetAPIs(clientCtx context.CLIContext, selectedApis []string, keys ...ethsec
 					Namespace: Web3Namespace,
 					Version:   apiVersion,
 					Service:   web3.NewAPI(),
-					Public:    true,
-				},
-			)
-		case EthNamespace:
-			apis = append(apis,
-				rpc.API{
-					Namespace: EthNamespace,
-					Version:   apiVersion,
-					Service:   ethAPI,
-					Public:    true,
-				},
-			)
-			apis = append(apis,
-				rpc.API{
-					Namespace: EthNamespace,
-					Version:   apiVersion,
-					Service:   filters.NewAPI(clientCtx, backend),
 					Public:    true,
 				},
 			)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #835 

## Description

The code requires the `eth` namespace for api to run the application. Prior to making the api modular, ALL namespaces have been enabled by default. With the most recent update to the API, #821, the `eth` api has been removed and is required by the user to include the namespace in the flag (`--rpc-api "eth"`). This would fix the error that is seen in the ticket this closes. 

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
